### PR TITLE
more than 8 map in ALLMAPS, color Palette error

### DIFF
--- a/assembly/allmaps.py
+++ b/assembly/allmaps.py
@@ -1541,7 +1541,7 @@ def plot(args):
     tip = .02
     marker_pos = {}
     # Palette
-    colors = dict((mapname, set2[i]) for i, mapname in enumerate(mapnames))
+    colors = dict((mapname, set2[i % len(set2)]) for i, mapname in enumerate(mapnames))
     colors = dict((mlg, colors[mlg.split("-")[0]]) for mlg in mlgs)
 
     rhos = {}


### PR DESCRIPTION
The error occurred because ALLMAPS supports only 8 color and hence index error.


Traceback (most recent call last):
  File "/home/wyim/bin/python2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/home/wyim/bin/python2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/data/wyim/won/bin/jcvi/jcvi_env/lib/python2.7/site-packages/jcvi-0.6.6-py2.7.egg/jcvi/assembly/allmaps.py", line 1725, in <module>
    main()
  File "/data/wyim/won/bin/jcvi/jcvi_env/lib/python2.7/site-packages/jcvi-0.6.6-py2.7.egg/jcvi/assembly/allmaps.py", line 824, in main
    p.dispatch(globals())
  File "/data/wyim/won/bin/jcvi/jcvi_env/lib/python2.7/site-packages/jcvi-0.6.6-py2.7.egg/jcvi/apps/base.py", line 82, in dispatch
    globals[action](sys.argv[2:])
  File "/data/wyim/won/bin/jcvi/jcvi_env/lib/python2.7/site-packages/jcvi-0.6.6-py2.7.egg/jcvi/assembly/allmaps.py", line 1379, in path
    "--figsize={0}".format(opts.figsize)])
  File "/data/wyim/won/bin/jcvi/jcvi_env/lib/python2.7/site-packages/jcvi-0.6.6-py2.7.egg/jcvi/assembly/allmaps.py", line 1721, in plotall
    plot(xargs + [seqid])
  File "/data/wyim/won/bin/jcvi/jcvi_env/lib/python2.7/site-packages/jcvi-0.6.6-py2.7.egg/jcvi/assembly/allmaps.py", line 1585, in plot
    colors = dict((mapname, set2[i]) for i, mapname in enumerate(mapnames))
  File "/data/wyim/won/bin/jcvi/jcvi_env/lib/python2.7/site-packages/jcvi-0.6.6-py2.7.egg/jcvi/assembly/allmaps.py", line 1585, in <genexpr>
    colors = dict((mapname, set2[i]) for i, mapname in enumerate(mapnames))
IndexError: list index out of range