### PR TITLE
add the argument --dbtype for LAST (jcvi.apps.align) and ortholog (jcvi.compara.catalog)

### DIFF
--- a/apps/align.py
+++ b/apps/align.py
@@ -274,14 +274,15 @@ def blast(args):
 
 
 @depends
-def run_lastdb(infile=None, outfile=None, mask=False, lastdb_bin="lastdb"):
+def run_lastdb(infile=None, outfile=None, mask=False, lastdb_bin="lastdb", dbtype="nucl"):
     outfilebase = outfile.rsplit(".", 1)[0]
+    db = "-p " if dbtype == "prot" else ""
     mask = "-c " if mask else ""
-    cmd = "{0} {1}{2} {3}".format(lastdb_bin, mask, outfilebase, infile)
+    cmd = "{0} {1}{2}{3} {4}".format(lastdb_bin, db, mask, outfilebase, infile)
     sh(cmd)
 
 
-def last(args):
+def last(args, dbtype=None):
     """
     %prog database.fasta query.fasta
 
@@ -291,6 +292,9 @@ def last(args):
     Works with LAST-719.
     """
     p = OptionParser(last.__doc__)
+    p.add_option("--dbtype", default="nucl",
+                 choices=("nucl", "prot"),
+                 help="Molecule type of subject database")
     p.add_option("--path", help="Specify LAST path")
     p.add_option("--mask", default=False, action="store_true", help="Invoke -c in lastdb")
     p.add_option("--format", default="BlastTab",
@@ -310,13 +314,15 @@ def last(args):
     subject, query = args
     path = opts.path
     cpus = opts.cpus
+    if not dbtype:
+        dbtype = opts.dbtype
     getpath = lambda x: op.join(path, x) if path else x
     lastdb_bin = getpath("lastdb")
     lastal_bin = getpath("lastal")
 
     subjectdb = subject.rsplit(".", 1)[0]
     run_lastdb(infile=subject, outfile=subjectdb + ".prj", mask=opts.mask, \
-              lastdb_bin=lastdb_bin)
+              lastdb_bin=lastdb_bin, dbtype=dbtype)
 
     u = 2 if opts.mask else 0
     cmd = "{0} -u {1}".format(lastal_bin, u)

--- a/compara/catalog.py
+++ b/compara/catalog.py
@@ -601,6 +601,9 @@ def ortholog(args):
     from jcvi.formats.blast import cscore, filter
 
     p = OptionParser(ortholog.__doc__)
+    p.add_option("--dbtype", default="nucl",
+                 choices=("nucl", "prot"),
+                 help="Molecule type of subject database")
     p.add_option("--full", default=False, action="store_true",
                  help="Run in full mode, including blocks and RBH")
     p.add_option("--cscore", default=0.7, type="float",
@@ -616,8 +619,10 @@ def ortholog(args):
         sys.exit(not p.print_help())
 
     a, b = args
-    abed, afasta = a + ".bed", a + ".cds"
-    bbed, bfasta = b + ".bed", b + ".cds"
+    dbtype = opts.dbtype
+    suffix = ".cds" if dbtype == "nucl" else ".pep"
+    abed, afasta = a + ".bed", a + suffix
+    bbed, bfasta = b + ".bed", b + suffix
     ccscore = opts.cscore
     quota = opts.quota
     dist = "--dist={0}".format(opts.dist)
@@ -628,7 +633,7 @@ def ortholog(args):
     qprefix = ".".join((bprefix, aprefix))
     last = pprefix + ".last"
     if need_update((afasta, bfasta), last):
-        last_main([bfasta, afasta])
+        last_main([bfasta, afasta], dbtype)
 
     if a == b:
         lastself = last + ".P98L0.inverse"


### PR DESCRIPTION
In some situations, users want to perform synteny analysis using protein sequences instead of CDS. I added  the argument `--dbtype` for LAST in jcvi.apps.align and ortholog in jcvi.compara.catalog. The argument could simplify the procedure, although the function can be achieved by running LAST or BLASTP separately and specifying the output filename as "query.subject.last".

Here is an example of *Glycine max* vs *Medicago truncatula*:

## Aligning protein sequences (Gm.pep, Gm.bed, Mt.pep, Mt.bed):

```
$ python -m jcvi.compara.catalog ortholog Gm Mt --dbtype=prot
grep '^###' Gm.Mt.anchors -c # 1,434 blocks
grep -v '^###' Gm.Mt.anchors -c # 40,013 anchors
```
![image](https://user-images.githubusercontent.com/22426230/30073725-87f0eed0-92a1-11e7-909d-9017e6a334e2.png)


## Aligning CDS (Gm.cds, Gm.bed, Mt.cds, Mt.bed):

```
$ python -m jcvi.compara.catalog ortholog Gm Mt
grep '^###' Gm.Mt.anchors -c # 1,305 blocks
grep -v '^###' Gm.Mt.anchors -c # 36,352 anchors
```
![image](https://user-images.githubusercontent.com/22426230/30073757-a727c170-92a1-11e7-9f14-6d7427dd6901.png)

### Results

Similar result but higher numbers of anchors and blocks. Besides, the anchors per block also slightly increased

