### PR TITLE
raise error while no anchor found

### DIFF
--- a/compara/synteny.py
+++ b/compara/synteny.py
@@ -1046,7 +1046,10 @@ def summary(args):
     anchorfile, = args
     ac = AnchorFile(anchorfile)
     clusters = ac.blocks
-
+    if clusters == [[]]:
+        logging.debug("A total of 0 anchor was found. Aborted.")
+        raise ValueError("A total of 0 anchor was found. Aborted.")
+    
     nclusters = len(clusters)
     nanchors = [len(c) for c in clusters]
     nranchors = [_score(c) for c in clusters]  # non-redundant anchors

--- a/compara/synteny.py
+++ b/compara/synteny.py
@@ -342,8 +342,7 @@ def read_anchors(ac, qorder, sorder, minsize=0):
         anchor_to_block[pair] = idx
         nanchors += 1
 
-    
-    ging.debug("A total of {0} anchors imported.".format(nanchors))
+    logging.debug("A total of {0} anchors imported.".format(nanchors))
     assert nanchors == len(anchor_to_block)
 
     return all_anchors, anchor_to_block

--- a/compara/synteny.py
+++ b/compara/synteny.py
@@ -342,7 +342,8 @@ def read_anchors(ac, qorder, sorder, minsize=0):
         anchor_to_block[pair] = idx
         nanchors += 1
 
-    logging.debug("A total of {0} anchors imported.".format(nanchors))
+    
+    ging.debug("A total of {0} anchors imported.".format(nanchors))
     assert nanchors == len(anchor_to_block)
 
     return all_anchors, anchor_to_block
@@ -1049,7 +1050,7 @@ def summary(args):
     if clusters == [[]]:
         logging.debug("A total of 0 anchor was found. Aborted.")
         raise ValueError("A total of 0 anchor was found. Aborted.")
-    
+
     nclusters = len(clusters)
     nanchors = [len(c) for c in clusters]
     nranchors = [_score(c) for c in clusters]  # non-redundant anchors


### PR DESCRIPTION
Print a friendly error message when no anchor are found.

## Before
```
11:03:27 [synteny] Assuming --qbed=Tva.bed --sbed=Pkn.bed
11:03:27 [base] Load file `Tva.bed`
11:03:28 [base] Load file `Pkn.bed`
11:03:28 [base] Load file `Tva.Pkn.last.filtered`
11:03:28 [synteny] A total of 6268 BLAST imported from `Tva.Pkn.last.filtered`.
11:03:28 [synteny] Chaining distance = 20
11:03:28 [base] Load file `Tva.Pkn.anchors`
11:03:28 [synteny] A total of 0 anchor was found. Aborted.
Traceback (most recent call last):
  File "/data/software/python27/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/data/software/python27/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/data/software/jcvi/compara/catalog.py", line 825, in <module>
    main()
  File "/data/software/jcvi/compara/catalog.py", line 73, in main
    p.dispatch(globals())
  File "/data/software/jcvi/apps/base.py", line 87, in dispatch
    globals[action](sys.argv[2:])
  File "/data/software/jcvi/compara/catalog.py", line 654, in ortholog
    "--liftover={0}".format(last)])
  File "/data/software/jcvi/compara/synteny.py", line 1483, in scan
    summary([anchor_file])
  File "/data/software/jcvi/compara/synteny.py", line 1051, in summary
    raise ValueError("A total of 0 anchor was found. Aborted.")
ValueError: A total of 0 anchor was found. Aborted.
```

## After
```
11:03:27 [synteny] Assuming --qbed=Tva.bed --sbed=Pkn.bed
11:03:27 [base] Load file `Tva.bed`
11:03:28 [base] Load file `Pkn.bed`
11:03:28 [base] Load file `Tva.Pkn.last.filtered`
11:03:28 [synteny] A total of 6268 BLAST imported from `Tva.Pkn.last.filtered`.
11:03:28 [synteny] Chaining distance = 20
11:03:28 [base] Load file `Tva.Pkn.anchors`
11:03:28 [synteny] A total of 0 anchor was found. Aborted.
Traceback (most recent call last):
  File "/data/software/python27/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/data/software/python27/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/data/software/jcvi/compara/catalog.py", line 825, in <module>
    main()
  File "/data/software/jcvi/compara/catalog.py", line 73, in main
    p.dispatch(globals())
  File "/data/software/jcvi/apps/base.py", line 87, in dispatch
    globals[action](sys.argv[2:])
  File "/data/software/jcvi/compara/catalog.py", line 654, in ortholog
    "--liftover={0}".format(last)])
  File "/data/software/jcvi/compara/synteny.py", line 1483, in scan
    summary([anchor_file])
  File "/data/software/jcvi/compara/synteny.py", line 1051, in summary
    raise ValueError("A total of 0 anchor was found. Aborted.")
ValueError: A total of 0 anchor was found. Aborted.
```