### PR TITLE
Add one-line description for each `jcvi` module

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+
+from jcvi.apps.base import dmain
+
+
+if __name__ == '__main__':
+    dmain(__file__, type="module")

--- a/algorithms/__main__.py
+++ b/algorithms/__main__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-
+"""
+Implementations of several key algorithms, such as: TSP, Graph, SuperMap, Linear Programming, ML, etc. used by other modules.
+"""
 
 from jcvi.apps.base import dmain
 

--- a/annotation/__main__.py
+++ b/annotation/__main__.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
+"""
+Collection of scripts to run gene finders, execute annotation pipelines, perform QC checks and generate summary statistics
+"""
 
 
 from jcvi.apps.base import dmain

--- a/apps/__main__.py
+++ b/apps/__main__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-
+"""
+Miscellany of wrapper scripts for command-line bioinformatics tools, public data downloaders and other generic routines.
+"""
 
 from jcvi.apps.base import dmain
 

--- a/assembly/__main__.py
+++ b/assembly/__main__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-
+"""
+Assemblage of genome-assembly related scripts: ALLMAPS algorithm, scaffolding, k-mer analysis, QC, tool wrappers, etc. 
+"""
 
 from jcvi.apps.base import dmain
 

--- a/compara/__main__.py
+++ b/compara/__main__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-
+"""
+Cluster of comparative genomics analysis methods: SynFind and QUOTA-ALIGN algorithms, synteny analysis, QC, etc. 
+"""
 
 from jcvi.apps.base import dmain
 

--- a/formats/__main__.py
+++ b/formats/__main__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-
+"""
+Array of data parsers for bioinformatics file formats, such as: GFF3, BED, SAM/BAM, VCF, PSL, AGP, FASTA/FASTQ, BLAST, etc. 
+"""
 
 from jcvi.apps.base import dmain
 

--- a/graphics/__main__.py
+++ b/graphics/__main__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-
+"""
+Suite of visualization tools for dot-plots, histograms, karytotypes, macro-/micro-synteny plots, seed counting using GRABSEEDS, etc. 
+"""
 
 from jcvi.apps.base import dmain
 

--- a/projects/__main__.py
+++ b/projects/__main__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-
+"""
+Compilation of project specific scripts, used to execute specific analysis routines and generate publication-ready figures
+"""
 
 from jcvi.apps.base import dmain
 

--- a/utils/__main__.py
+++ b/utils/__main__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-
+"""
+Assortment of utility scripts implementing recipes from Python cookbooks, such as iterators, sorters, range queries, etc. 
+"""
 
 from jcvi.apps.base import dmain
 

--- a/variation/__main__.py
+++ b/variation/__main__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-
+"""
+Set of scripts relating to variation studies such as imputation, phasing, SNP/CNV analysis, and other supporting routines
+"""
 
 from jcvi.apps.base import dmain
 


### PR DESCRIPTION
Docstring in `module/__main__.py` is used to show help text when invoking `python -m jcvi`.

Ref #70