### PR TITLE
The variable "block_color" was unexpected reset

### DIFF
--- a/graphics/dotplot.py
+++ b/graphics/dotplot.py
@@ -168,9 +168,9 @@ def dotplot(anchorfile, qbed, sbed, fig, root, ax, vmin=0, vmax=1,
                         .format(vmin, vmax))
 
     block_id = 0
+    block_color = None
     for row in fp:
         atoms = row.split()
-        block_color = None
         if row[0] == "#":
             block_id += 1
             if palette:


### PR DESCRIPTION
Put "block_color = None" inside the for loop will disable the "--colormap" option