### PR TITLE
Add alternative style for gene glyphs (#256, thanks @Tong-Chen)

### DIFF
--- a/jcvi/graphics/glyph.py
+++ b/jcvi/graphics/glyph.py
@@ -17,6 +17,7 @@ from jcvi.graphics.base import (
     Rectangle,
     CirclePolygon,
     Ellipse,
+    FancyArrowPatch,
     Polygon,
     savefig,
     get_map,
@@ -204,16 +205,43 @@ class BaseGlyph(list):
 
 
 class Glyph(BaseGlyph):
-    """Draws gradient rectangle
-    """
 
-    def __init__(self, ax, x1, x2, y, height=0.04, gradient=True, fc="gray", **kwargs):
+    Styles = ("box", "arrow")
+
+    def __init__(
+        self,
+        ax,
+        x1,
+        x2,
+        y,
+        height=0.04,
+        gradient=True,
+        fc="gray",
+        style="box",
+        **kwargs
+    ):
+        """ Draw a region that represent an interval feature, e.g. gene or repeat
+
+        Args:
+            ax (matplotlib.axis): matplot axis object
+            x1 (float): start coordinate
+            x2 (float): end coordinate
+            y (float): y coordinate. Note that the feature is horizontally drawn.
+            height (float, optional): Height of the feature. Defaults to 0.04.
+            gradient (bool, optional): Shall we draw color gradient on the box? Defaults to True.
+            fc (str, optional): Face color of the feature. Defaults to "gray".
+            style (str, optional): Style, either box|arrow. Defaults to "box".
+        """
 
         super(Glyph, self).__init__(ax)
         width = x2 - x1
         # Frame around the gradient rectangle
         p1 = (x1, y - 0.5 * height)
-        self.append(Rectangle(p1, width, height, fc=fc, lw=0, **kwargs))
+        if style == "arrow":
+            patch = FancyArrowPatch((x1, y), (x2, y), fc=fc, lw=0, **kwargs)
+        else:
+            patch = Rectangle(p1, width, height, fc=fc, lw=0, **kwargs)
+        self.append(patch)
 
         # Several overlaying patches
         if gradient:

--- a/jcvi/graphics/glyph.py
+++ b/jcvi/graphics/glyph.py
@@ -207,6 +207,7 @@ class BaseGlyph(list):
 class Glyph(BaseGlyph):
 
     Styles = ("box", "arrow")
+    ArrowStyle = "Simple,head_length=1.5,head_width=7,tail_width=7"
 
     def __init__(
         self,
@@ -217,6 +218,8 @@ class Glyph(BaseGlyph):
         height=0.04,
         gradient=True,
         fc="gray",
+        ec="gainsboro",
+        lw=0,
         style="box",
         **kwargs
     ):
@@ -238,9 +241,19 @@ class Glyph(BaseGlyph):
         # Frame around the gradient rectangle
         p1 = (x1, y - 0.5 * height)
         if style == "arrow":
-            patch = FancyArrowPatch((x1, y), (x2, y), fc=fc, lw=0, **kwargs)
+            patch = FancyArrowPatch(
+                (x1, y),
+                (x2, y),
+                shrinkA=0,
+                shrinkB=0,
+                arrowstyle=self.ArrowStyle,
+                fc=fc,
+                ec=ec,
+                lw=lw,
+                **kwargs
+            )
         else:
-            patch = Rectangle(p1, width, height, fc=fc, lw=0, **kwargs)
+            patch = Rectangle(p1, width, height, fc=fc, ec=ec, lw=lw, **kwargs)
         self.append(patch)
 
         # Several overlaying patches

--- a/jcvi/graphics/synteny.py
+++ b/jcvi/graphics/synteny.py
@@ -172,6 +172,7 @@ class Region(object):
         pad=0.05,
         vpad=0.015,
         extra_features=None,
+        glyphstyle="box",
     ):
         x, y = layout.x, layout.y
         ratio = layout.ratio
@@ -226,7 +227,17 @@ class Region(object):
 
             color = forward if strand == "+" else backward
             if not hidden:
-                gp = Glyph(ax, x1, x2, y, height, gradient=False, fc=color, zorder=3)
+                gp = Glyph(
+                    ax,
+                    x1,
+                    x2,
+                    y,
+                    height,
+                    gradient=False,
+                    fc=color,
+                    style=glyphstyle,
+                    zorder=3,
+                )
                 gp.set_transform(tr)
 
         # Extra features (like repeats)
@@ -242,6 +253,7 @@ class Region(object):
                     height * 3 / 4,
                     gradient=False,
                     fc="#ff7f00",
+                    style=glyphstyle,
                     zorder=2,
                 )
                 gp.set_transform(tr)
@@ -327,6 +339,7 @@ class Synteny(object):
         vpad=0.015,
         scalebar=False,
         shadestyle="curve",
+        glyphstyle="arrow",
     ):
 
         w, h = fig.get_figwidth(), fig.get_figheight()
@@ -378,6 +391,7 @@ class Synteny(object):
                 loc_label=loc_label,
                 vpad=vpad,
                 extra_features=ef,
+                glyphstyle=glyphstyle,
             )
             self.rr.append(r)
             # Use tid and accn to store gene positions
@@ -467,7 +481,9 @@ class Synteny(object):
                 RoundLabel(ax, 0.5, 0.3, label, fill=True, fc="lavender", color=color)
 
 
-def draw_gene_legend(ax, x1, x2, ytop, d=0.04, text=False, repeat=False):
+def draw_gene_legend(
+    ax, x1, x2, ytop, d=0.04, text=False, repeat=False, glyphstyle="box",
+):
     ax.plot([x1, x1 + d], [ytop, ytop], ":", color=forward, lw=2)
     ax.plot([x1 + d], [ytop], ">", color=forward, mec=forward)
     ax.plot([x2, x2 + d], [ytop, ytop], ":", color=backward, lw=2)
@@ -485,6 +501,7 @@ def draw_gene_legend(ax, x1, x2, ytop, d=0.04, text=False, repeat=False):
             0.012 * 3 / 4,
             gradient=False,
             fc="#ff7f00",
+            style=glyphstyle,
             zorder=2,
         )
         ax.text(xr, ytop + d / 2, "repeat", ha="center")
@@ -492,18 +509,20 @@ def draw_gene_legend(ax, x1, x2, ytop, d=0.04, text=False, repeat=False):
 
 def main():
     p = OptionParser(__doc__)
-    p.add_option(
-        "--switch", help="Rename the seqid with two-column file [default: %default]"
-    )
-    p.add_option(
-        "--tree", help="Display trees on the bottom of the figure [default: %default]"
-    )
+    p.add_option("--switch", help="Rename the seqid with two-column file")
+    p.add_option("--tree", help="Display trees on the bottom of the figure")
     p.add_option("--extra", help="Extra features in BED format")
     p.add_option(
         "--scalebar",
         default=False,
         action="store_true",
         help="Add scale bar to the plot",
+    )
+    p.add_option(
+        "--glyphstyle",
+        default="box",
+        choices=Glyph.Styles,
+        help="Style of feature glyphs",
     )
     p.add_option(
         "--shadestyle",
@@ -535,6 +554,7 @@ def main():
         extra_features=opts.extra,
         scalebar=opts.scalebar,
         shadestyle=opts.shadestyle,
+        glyphstyle=opts.glyphstyle,
     )
 
     root.set_xlim(0, 1)


### PR DESCRIPTION
Add option `--glyphstyle arrow` in addition to the rectangle glyph (default)

![Jun-12-2020 20-25-41](https://user-images.githubusercontent.com/106987/84558925-544f5a00-aceb-11ea-882c-23b082b7976d.gif)
