### PR TITLE
Update pad.py

### DIFF
--- a/jcvi/compara/pad.py
+++ b/jcvi/compara/pad.py
@@ -263,7 +263,7 @@ def cluster(args):
 
     id = 0
     for block in ac.iter_blocks(minsize=minsize):
-        q, s = zip(*block)[:2]
+        q, s = list(zip(*block))[:2]
         q = [qorder[x][0] for x in q]
         s = [sorder[x][0] for x in s]
         minq, maxq = min(q), max(q)


### PR DESCRIPTION
In Python 2, zip returned a list. In Python 3, zip returns an iterable object.