### PR TITLE
Update of stats.py

### DIFF
--- a/jcvi/annotation/stats.py
+++ b/jcvi/annotation/stats.py
@@ -171,6 +171,8 @@ def genestats(args):
         fid = feat.id
         transcripts = [c.id for c in g.children(fid, 1) \
                          if c.featuretype == "mRNA"]
+        if len(transcripts) == 0:
+            continue
         transcript_sizes = [tsizes[x] for x in transcripts]
         exons = set((c.chrom, c.start, c.stop) for c in g.children(fid, 2) \
                          if c.featuretype == "exon")

--- a/jcvi/annotation/stats.py
+++ b/jcvi/annotation/stats.py
@@ -208,7 +208,7 @@ def genestats(args):
         mean_num_transcripts = num_transcripts * 1. / num_genes
         mean_locus_size = cum_locus_size * 1. / num_genes
         mean_transcript_size = cum_transcript_size * 1. / num_transcripts
-        mean_exon_size = cum_exon_size * 1. / num_exons
+        mean_exon_size = cum_exon_size * 1. / num_exons if num_exons != 0 else 0
 
         r[("Number of genes", g)] = num_genes
         r[("Number of single-exon genes", g)] = \

--- a/jcvi/annotation/stats.py
+++ b/jcvi/annotation/stats.py
@@ -151,7 +151,7 @@ def genestats(args):
     gb = opts.groupby
     g = make_index(gff_file)
 
-    tf = "transcript.sizes"
+    tf = gff_file + ".transcript.sizes"
     if need_update(gff_file, tf):
         fw = open(tf, "w")
         for feat in g.features_of_type("mRNA"):


### PR DESCRIPTION
If there are many GFF under a same directory and we run `python -m jcvi.annotation.stats genestats`  for each of them, we will get unexpected result because the origin code will generate one "transcript.sizes" file to different GFF file. So It is better to generate "transcript.sizes" with the filename of GFF as prefix to avoid this problem.

If the gff file have a rRNA as feature, some gene will not have mRNA as feature.

If the gff don't have have exon as feature, the num_exons is zero . 