### PR TITLE
Set ubuntu base to non-interactive during image build

### DIFF
--- a/docker/jcvi.dockerfile
+++ b/docker/jcvi.dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:latest
+ARG DEBIAN_FRONTEND=noninteractive
 MAINTAINER tanghaibao@gmail.com
 
 RUN apt-get update


### PR DESCRIPTION
Even with -y option on apt-get installs, certain libraries (libxml2-dev) will
prompt for locale info (tzdata) causing hang during build. Setting debian_frontend as
non interactive with ARG rather than ENV changes the behavior during the build
only.