### PR TITLE
Set "success" flag to True in base.py if file exists to avoid shredding

### DIFF
--- a/jcvi/apps/base.py
+++ b/jcvi/apps/base.py
@@ -1424,6 +1424,7 @@ def download(
         if debug:
             msg = "File `{}` exists. Download skipped.".format(final_filename)
             logging.error(msg)
+            success = True
     else:
         from jcvi.utils.ez_setup import get_best_downloader
 


### PR DESCRIPTION
base.py "download" function checks if fetch request already exists and skips download if true.
"success" flag remains false so that at line 1453, file shredder is invoked. Missing directory file
then causes subsequent fetch request (e.g. species fetch) to fail.
What we observe is that any initial request works, signon success, directory listing download success.
Subsequent fetch (of directory or species) then fails due to above, then cookies and directory are
deleted. Next fetch requires signon again and succeeds, next one fails, etc.