### PR TITLE
type1ec.sty required for LaTeX, add cm-super font package to containe…

### DIFF
--- a/docker/jcvi.dockerfile
+++ b/docker/jcvi.dockerfile
@@ -20,7 +20,7 @@ RUN pip install scipy
 # <https://github.com/tanghaibao/jcvi/wiki/GRABSEEDS%3A-How-to-install>
 RUN apt-get install -y libxft-dev libfreetype6 libfreetype6-dev
 RUN apt-get install -y libmagickwand-dev
-RUN apt-get install -y texlive texlive-latex-extra texlive-latex-recommended
+RUN apt-get install -y texlive texlive-latex-extra texlive-latex-recommended cm-super
 RUN apt-get install -y dvipng
 
 RUN pip install matplotlib scikit-image pypdf2 wand Pillow


### PR DESCRIPTION
…r build

Latex/matplotlib interaction looks for but can't find type1ec.sty file. this may
be included in texlive-latex-extra for some texlive distributions but not for the
minimal ubuntu derivative this image is based on.