### PR TITLE
Allow glyphcolor to be specified according to a palette

### DIFF
--- a/jcvi/compara/synteny.py
+++ b/jcvi/compara/synteny.py
@@ -314,7 +314,7 @@ def get_orientation(ia, ib):
     if len(ia) != len(ib) or len(ia) < 2:
         return "+"  # Just return a default orientation
 
-    slope, intercept = np.polyfit(ia, ib, 1)
+    slope, _ = np.polyfit(ia, ib, 1)
     return "+" if slope >= 0 else "-"
 
 

--- a/jcvi/compara/synteny.py
+++ b/jcvi/compara/synteny.py
@@ -32,7 +32,7 @@ class AnchorFile(BaseFile):
 
     def iter_blocks(self, minsize=0):
         fp = open(self.filename)
-        for header, lines in read_block(fp, "#"):
+        for _, lines in read_block(fp, "#"):
             lines = [x.split() for x in lines]
             if len(lines) >= minsize:
                 yield lines
@@ -89,9 +89,9 @@ class AnchorFile(BaseFile):
                 print("\t".join((a, b, score)), file=fw)
         fw.close()
 
-        logging.debug("Removed {0} existing anchors.".format(nremoved))
-        logging.debug("Corrected scores for {0} anchors.".format(ncorrected))
-        logging.debug("Anchors written to `{0}`.".format(filename))
+        logging.debug("Removed %d existing anchors.", nremoved)
+        logging.debug("Corrected scores for %d anchors.", ncorrected)
+        logging.debug("Anchors written to `%s`.", filename)
 
     def blast(self, blastfile=None, outfile=None):
         """
@@ -109,7 +109,7 @@ class AnchorFile(BaseFile):
 
         fw = must_open(outfile, "w", checkexists=True)
         nlines = 0
-        for a, b, id in self.iter_pairs():
+        for a, b, _ in self.iter_pairs():
             if (a, b) in blasts:
                 bline = blasts[(a, b)]
             elif (b, a) in blasts:
@@ -122,9 +122,7 @@ class AnchorFile(BaseFile):
             nlines += 1
         fw.close()
 
-        logging.debug(
-            "A total of {0} BLAST lines written to `{1}`.".format(nlines, outfile)
-        )
+        logging.debug("A total of %d BLAST lines written to `%s`.", nlines, outfile)
 
         return outfile
 

--- a/jcvi/compara/synteny.py
+++ b/jcvi/compara/synteny.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
-from __future__ import print_function
+"""Syntenty inference in comparative genomics
+"""
 
 import os.path as op
 import sys
@@ -133,6 +134,8 @@ class AnchorFile(BaseFile):
 
 
 class BlockFile(BaseFile):
+    """Parse .blocks file which is the mcscan output with multiple columns as 'tracks'"""
+
     def __init__(self, filename, defaultcolor="#fb8072", header=False):
         super(BlockFile, self).__init__(filename)
         fp = must_open(filename)
@@ -254,6 +257,15 @@ class BlockFile(BaseFile):
                 line = color + "*" + line
             yield line
 
+    def grouper(self) -> Grouper:
+        """Build orthogroup based on the gene matches."""
+        grouper = Grouper()
+        for row in self.data:
+            if "." not in row:
+                grouper.join(*row)
+        logging.debug("A total of %d orthogroups formed", len(grouper))
+        return grouper
+
 
 class SimpleFile(object):
     def __init__(self, simplefile, defaultcolor="#fb8072", order=None):
@@ -286,8 +298,7 @@ class SimpleFile(object):
             self.blocks.append((a, b, c, d, score, orientation, hl))
         if check:
             print(
-                """Error: some genes in blocks can't be found,
-please rerun after making sure that bed file agree with simple file.""",
+                "Error: some genes in blocks can't be found, please rerun after making sure that bed file agree with simple file.",
                 file=sys.stderr,
             )
             exit(1)
@@ -373,9 +384,7 @@ def read_blast(blast_file, qorder, sorder, is_self=False, ostrip=True):
         filtered_blast.append(b)
 
     logging.debug(
-        "A total of {0} BLAST imported from `{1}`.".format(
-            len(filtered_blast), blast_file
-        )
+        "A total of %d BLAST imported from `%s`.", len(filtered_blast), blast_file
     )
 
     return filtered_blast

--- a/jcvi/graphics/base.py
+++ b/jcvi/graphics/base.py
@@ -221,7 +221,12 @@ def set3_n(number=12):
     return get_map("Set3", "qualitative", number).hex_colors
 
 
-set1, set2, set3 = set1_n(), set2_n(), set3_n()
+def paired_n(number=12):
+    """See also: https://colorbrewer2.org/#type=qualitative&scheme=Paired&n=12"""
+    return get_map("Paired", "qualitative", number).hex_colors
+
+
+set1, set2, set3, paired = set1_n(), set2_n(), set3_n(), paired_n()
 
 
 def prettyplot():

--- a/jcvi/graphics/glyph.py
+++ b/jcvi/graphics/glyph.py
@@ -23,6 +23,7 @@ from jcvi.graphics.base import (
     set3,
     get_map,
 )
+from jcvi.utils.grouper import Grouper
 
 
 tstep = 0.05
@@ -190,6 +191,17 @@ class TextCircle(object):
 class BasePalette(dict):
     """Base class for coloring gene glyphs"""
 
+    def get_color(self, feature: str) -> str:
+        """Get color based on the orientation.
+
+        Args:
+            feature (str): orientation, name etc.
+
+        Returns:
+            str: color for the given orientation
+        """
+        return self.palette.get(feature)
+
 
 class OrientationPalette(BasePalette):
     """Color gene glyphs with forward/reverse"""
@@ -197,33 +209,35 @@ class OrientationPalette(BasePalette):
     forward, backward = "b", "g"  # Genes with different orientations
     palette = {"+": forward, "-": backward}
 
-    def get_color(self, orientation: str) -> str:
-        """Get color based on the orientation.
-
-        Args:
-            orientation (str): +/-
-
-        Returns:
-            str: color for the given orientation
-        """
-        return self.palette.get(orientation)
-
 
 class OrthoGroupPalette(BasePalette):
     """Color gene glyphs with random orthogroup color"""
 
+    grouper: Grouper
     palette = set3
 
-    def get_color(self, orthogroup) -> str:
-        """Get color based on random orthogroup color.
+    def __init__(self, grouper: Grouper):
+        """Initialize with grouper instance indicating orthogroup assignments.
 
         Args:
-            orthogroup (hashable): Anything that implements __hash__
+            grouper (Grouper): Orthogroup assignments
+        """
+        super().__init__()
+        self.grouper = grouper
+
+    def get_color(self, feature: str) -> str:
+        """Get color based on orthogroup assignement of a gene.
+
+        Args:
+            feature (str): Name of the gene
 
         Returns:
-            str: color for the given orthogroup
+            str: Name of the matplotlib color, #aabbcc or magenta etc.
         """
-        return self.palette[hash(orthogroup) % len(self.palette)]
+        if feature not in self.grouper:
+            return "gray"
+        group = self.grouper[feature]
+        return self.palette[hash(group) % len(self.palette)]
 
 
 class BaseGlyph(list):

--- a/jcvi/graphics/glyph.py
+++ b/jcvi/graphics/glyph.py
@@ -191,16 +191,17 @@ class TextCircle(object):
 class BasePalette(dict):
     """Base class for coloring gene glyphs"""
 
-    def get_color(self, feature: str) -> str:
-        """Get color based on the orientation.
+    def get_color_and_zorder(self, feature: str) -> (str, int):
+        """Get color and zorder based on the orientation.
 
         Args:
             feature (str): orientation, name etc.
 
         Returns:
-            str: color for the given orientation
+            (str, int): color and zorder for the given orientation
         """
-        return self.palette.get(feature)
+        color = self.palette.get(feature)
+        return color, 4
 
 
 class OrientationPalette(BasePalette):
@@ -225,7 +226,7 @@ class OrthoGroupPalette(BasePalette):
         super().__init__()
         self.grouper = grouper
 
-    def get_color(self, feature: str) -> str:
+    def get_color_and_zorder(self, feature: str) -> str:
         """Get color based on orthogroup assignement of a gene.
 
         Args:
@@ -235,9 +236,10 @@ class OrthoGroupPalette(BasePalette):
             str: Name of the matplotlib color, #aabbcc or magenta etc.
         """
         if feature not in self.grouper:
-            return "gray"
+            return ("gray", 3)
         group = self.grouper[feature]
-        return self.palette[hash(group) % len(self.palette)]
+        # Any gene part of an orthogroup gets a higher zorder
+        return (self.palette[hash(group) % len(self.palette)], 4)
 
 
 class BaseGlyph(list):

--- a/jcvi/graphics/glyph.py
+++ b/jcvi/graphics/glyph.py
@@ -191,7 +191,7 @@ class TextCircle(object):
 class BasePalette(dict):
     """Base class for coloring gene glyphs"""
 
-    def get_color_and_zorder(self, feature: str) -> (str, int):
+    def get_color_and_zorder(self, feature: str) -> tuple:
         """Get color and zorder based on the orientation.
 
         Args:
@@ -226,14 +226,14 @@ class OrthoGroupPalette(BasePalette):
         super().__init__()
         self.grouper = grouper
 
-    def get_color_and_zorder(self, feature: str) -> str:
+    def get_color_and_zorder(self, feature: str) -> tuple:
         """Get color based on orthogroup assignement of a gene.
 
         Args:
             feature (str): Name of the gene
 
         Returns:
-            str: Name of the matplotlib color, #aabbcc or magenta etc.
+            str: color and zorder for the given gene_name based on the assignment
         """
         if feature not in self.grouper:
             return ("gray", 3)

--- a/jcvi/graphics/synteny.py
+++ b/jcvi/graphics/synteny.py
@@ -167,7 +167,6 @@ class Region(object):
         layout,
         bed,
         scale,
-        glyphcolor: BasePalette,
         switch=None,
         chr_label=True,
         loc_label=True,
@@ -176,6 +175,7 @@ class Region(object):
         vpad=0.015,
         extra_features=None,
         glyphstyle="box",
+        glyphcolor: BasePalette = OrientationPalette(),
     ):
         x, y = layout.x, layout.y
         ratio = layout.ratio
@@ -350,7 +350,6 @@ class Synteny(object):
         datafile,
         bedfile,
         layoutfile,
-        glyphcolor: BasePalette,
         switch=None,
         tree=None,
         extra_features=None,
@@ -362,6 +361,7 @@ class Synteny(object):
         scalebar=False,
         shadestyle="curve",
         glyphstyle="arrow",
+        glyphcolor: BasePalette = OrientationPalette(),
     ):
         w, h = fig.get_figwidth(), fig.get_figheight()
         bed = Bed(bedfile)
@@ -397,7 +397,6 @@ class Synteny(object):
         self.gg = gg = {}
         self.rr = []
         ymids = []
-        # vpad = .012 * w / h
         for i in range(bf.ncols):
             ext = exts[i]
             ef = extras[i] if extras else None
@@ -407,7 +406,6 @@ class Synteny(object):
                 lo[i],
                 bed,
                 scale,
-                glyphcolor,
                 switch,
                 genelabelsize=genelabelsize,
                 chr_label=chr_label,
@@ -415,6 +413,7 @@ class Synteny(object):
                 vpad=vpad,
                 extra_features=ef,
                 glyphstyle=glyphstyle,
+                glyphcolor=glyphcolor,
             )
             self.rr.append(r)
             # Use tid and accn to store gene positions
@@ -599,7 +598,6 @@ def main():
         datafile,
         bedfile,
         layoutfile,
-        glyphcolor,
         switch=switch,
         tree=tree,
         extra_features=opts.extra,
@@ -607,6 +605,7 @@ def main():
         scalebar=opts.scalebar,
         shadestyle=opts.shadestyle,
         glyphstyle=opts.glyphstyle,
+        glyphcolor=glyphcolor,
     )
 
     root.set_xlim(0, 1)

--- a/jcvi/graphics/synteny.py
+++ b/jcvi/graphics/synteny.py
@@ -229,10 +229,10 @@ class Region(object):
             gene_name = g.accn
             self.gg[gene_name] = (a, b)
 
-            color = (
-                glyphcolor.get_color(strand)
+            color, zorder = (
+                glyphcolor.get_color_and_zorder(strand)
                 if isinstance(glyphcolor, OrientationPalette)
-                else glyphcolor.get_color(gene_name)
+                else glyphcolor.get_color_and_zorder(gene_name)
             )
 
             if hidden:
@@ -246,7 +246,7 @@ class Region(object):
                 gradient=False,
                 fc=color,
                 style=glyphstyle,
-                zorder=3,
+                zorder=zorder,
             )
             gp.set_transform(tr)
             if genelabelsize:


### PR DESCRIPTION
We abstracted the color palette using separated classes

- `OrientationPalette` plots gene colors based on orientation
- `OrthogroupPalette` plots gene colors based on given orthogroups from blocks file

---
The following section is added to wiki.

Sometimes we want to match the colors of the genes with respect to their homology as indicated in the `blocks` file.

    $ python -m jcvi.graphics.synteny blocks grape_peach.bed blocks.layout --glyphcolor=orthogroup

![Grape-peach-blocks-orthogroup](https://www.dropbox.com/s/qgdagaqaethwj0v/Grape-peach-blocks-orthogroup.png?raw=1)

