### PR TITLE
Fix py2=>py3: fp.next() converted to next(fp) (thanks @agroppi, #363)

### DIFF
--- a/jcvi/annotation/evm.py
+++ b/jcvi/annotation/evm.py
@@ -52,11 +52,11 @@ $EVM/TIGR-only/TIGR_EVM_loader.pl --db {0} \
 def main():
 
     actions = (
-        ('pasa', 'extract terminal exons'),
-        ('tigrprepare', 'run EVM in TIGR-only mode'),
-        ('tigrload', 'load EVM results into TIGR db'),
-        ('maker', 'run EVM based on MAKER output'),
-            )
+        ("pasa", "extract terminal exons"),
+        ("tigrprepare", "run EVM in TIGR-only mode"),
+        ("tigrload", "load EVM results into TIGR db"),
+        ("maker", "run EVM based on MAKER output"),
+    )
     p = ActionDispatcher(actions)
     p.dispatch(globals())
 
@@ -91,7 +91,7 @@ def maker(args):
 
     A, T, P = "ABINITIO_PREDICTION", "TRANSCRIPT", "PROTEIN"
     # Stores default weights and types
-    Registry = {\
+    Registry = {
         "maker": (A, 5),
         "augustus_masked": (A, 1),
         "snap_masked": (A, 1),
@@ -99,7 +99,7 @@ def maker(args):
         "est2genome": (T, 5),
         "est_gff": (T, 5),
         "protein2genome": (P, 5),
-        "blastx": (P, 1)
+        "blastx": (P, 1),
     }
 
     p = OptionParser(maker.__doc__)
@@ -136,7 +136,9 @@ def maker(args):
 
     for type, tracks in reg.items():
         for t in tracks:
-            cmd = "grep '\t{0}' {1} | grep -v '_match\t' >> {2}.gff".format(t, gffile, type)
+            cmd = "grep '\t{0}' {1} | grep -v '_match\t' >> {2}.gff".format(
+                t, gffile, type
+            )
             sh(cmd)
 
     partition(evs)
@@ -183,7 +185,7 @@ def pasa(args):
     if need_update(fastafile, termexons):
         cmd = "$ANNOT_DEVEL/PASA2/scripts/pasa_asmbls_to_training_set.dbi"
         cmd += ' -M "{0}:mysql.tigr.org" -p "access:access"'.format(pasa_db)
-        cmd += ' -g {0}'.format(fastafile)
+        cmd += " -g {0}".format(fastafile)
         sh(cmd)
 
         cmd = "$EVM/PasaUtils/retrieve_terminal_CDS_exons.pl"
@@ -230,14 +232,14 @@ def tigrprepare(args):
         sys.exit(not p.print_help())
 
     fastafile, asmbl_id, db, pasa_db = args
-    if asmbl_id == 'all':
+    if asmbl_id == "all":
         idsfile = fastafile + ".ids"
         if need_update(fastafile, idsfile):
             ids([fastafile, "-o", idsfile])
     else:
         idsfile = asmbl_id
 
-    oneid = open(idsfile).next().strip()
+    oneid = next(open(idsfile)).strip()
 
     weightsfile = "weights.txt"
     if need_update(idsfile, weightsfile):
@@ -245,12 +247,14 @@ def tigrprepare(args):
         cmd += " {0} {1} | tee weights.txt".format(db, oneid)
         sh(cmd)
 
-    evs = ["gene_predictions.gff3", "transcript_alignments.gff3",
-           "protein_alignments.gff3"]
+    evs = [
+        "gene_predictions.gff3",
+        "transcript_alignments.gff3",
+        "protein_alignments.gff3",
+    ]
     if need_update(weightsfile, evs):
         cmd = "$EVM/TIGR-only/write_GFF3_files.dbi"
-        cmd += " --db {0} --asmbl_id {1} --weights {2}".\
-                format(db, idsfile, weightsfile)
+        cmd += " --db {0} --asmbl_id {1} --weights {2}".format(db, idsfile, weightsfile)
         sh(cmd)
 
     evs[1] = fix_transcript()
@@ -261,5 +265,5 @@ def tigrprepare(args):
     write_file(runfile, contents)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/jcvi/apps/bowtie.py
+++ b/jcvi/apps/bowtie.py
@@ -15,14 +15,13 @@ import logging
 from jcvi.formats.base import BaseFile
 from jcvi.utils.cbook import percentage
 from jcvi.formats.sam import output_bam, get_prefix, get_samfile
-from jcvi.apps.base import OptionParser, ActionDispatcher, need_update, sh, \
-            get_abs_path
+from jcvi.apps.base import OptionParser, ActionDispatcher, need_update, sh, get_abs_path
 
 
-first_tag = lambda fp: fp.next().split()[0]
+first_tag = lambda fp: next(fp).split()[0]
 
 
-class BowtieLogFile (BaseFile):
+class BowtieLogFile(BaseFile):
     """
     Simple file that contains mapping rate:
 
@@ -33,6 +32,7 @@ class BowtieLogFile (BaseFile):
         1775 (1.77%) aligned >1 times
     11.55% overall alignment rate
     """
+
     def __init__(self, filename):
 
         super(BowtieLogFile, self).__init__(filename)
@@ -47,8 +47,7 @@ class BowtieLogFile (BaseFile):
         fp.close()
 
     def __str__(self):
-        return "Total mapped: {0}".format(\
-                percentage(self.mapped, self.total))
+        return "Total mapped: {0}".format(percentage(self.mapped, self.total))
 
     __repr__ = __str__
 
@@ -56,9 +55,9 @@ class BowtieLogFile (BaseFile):
 def main():
 
     actions = (
-        ('index', 'wraps bowtie2-build'),
-        ('align', 'wraps bowtie2'),
-            )
+        ("index", "wraps bowtie2-build"),
+        ("align", "wraps bowtie2"),
+    )
     p = ActionDispatcher(actions)
     p.dispatch(globals())
 
@@ -87,7 +86,7 @@ def index(args):
     if len(args) != 1:
         sys.exit(not p.print_help())
 
-    dbfile, = args
+    (dbfile,) = args
     check_index(dbfile)
 
 
@@ -101,14 +100,27 @@ def align(args):
 
     p = OptionParser(align.__doc__)
     p.set_firstN(firstN=0)
-    p.add_option("--full", default=False, action="store_true",
-                 help="Enforce end-to-end alignment [default: local]")
-    p.add_option("--reorder", default=False, action="store_true",
-                 help="Keep the input read order [default: %default]")
-    p.add_option("--null", default=False, action="store_true",
-                 help="Do not write to SAM/BAM output")
-    p.add_option("--fasta", default=False, action="store_true",
-                 help="Query reads are FASTA")
+    p.add_option(
+        "--full",
+        default=False,
+        action="store_true",
+        help="Enforce end-to-end alignment [default: local]",
+    )
+    p.add_option(
+        "--reorder",
+        default=False,
+        action="store_true",
+        help="Keep the input read order",
+    )
+    p.add_option(
+        "--null",
+        default=False,
+        action="store_true",
+        help="Do not write to SAM/BAM output",
+    )
+    p.add_option(
+        "--fasta", default=False, action="store_true", help="Query reads are FASTA"
+    )
     p.set_cutoff(cutoff=800)
     p.set_mateorientation(mateorientation="+-")
     p.set_sam_options(bowtie=True)
@@ -116,9 +128,9 @@ def align(args):
     opts, args = p.parse_args(args)
     extra = opts.extra
     mo = opts.mateorientation
-    if mo == '+-':
+    if mo == "+-":
         extra += ""
-    elif mo == '-+':
+    elif mo == "-+":
         extra += "--rf"
     else:
         extra += "--ff"
@@ -141,9 +153,9 @@ def align(args):
     dbfile, readfile = args[0:2]
     dbfile = check_index(dbfile)
     prefix = get_prefix(readfile, dbfile)
-    samfile, mapped, unmapped = get_samfile(readfile, dbfile, bowtie=True,
-                                            mapped=mapped, unmapped=unmapped,
-                                            bam=opts.bam)
+    samfile, mapped, unmapped = get_samfile(
+        readfile, dbfile, bowtie=True, mapped=mapped, unmapped=unmapped, bam=opts.bam
+    )
     logfile = prefix + ".log"
     if not fasta:
         offset = guessoffset([readfile])
@@ -192,5 +204,5 @@ def align(args):
     return samfile, logfile
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/jcvi/assembly/ca.py
+++ b/jcvi/assembly/ca.py
@@ -319,7 +319,7 @@ def overlap(args):
     cmd += " -tabular -dumpfragments ../asm.gkpStore"
     fp = popen(cmd)
     row = next(fp)
-    size = int(fp.next().split()[-1])
+    size = int(next(fp).split()[-1])
 
     # Determine size of canvas
     xmin = min(x.ahang for x in frags)

--- a/jcvi/assembly/opticalmap.py
+++ b/jcvi/assembly/opticalmap.py
@@ -218,7 +218,7 @@ def silicosoma(args):
     fp = must_open(silicofile)
     fw = must_open(opts.outfile, "w")
     next(fp)
-    positions = [int(x) for x in fp.next().split()]
+    positions = [int(x) for x in next(fp).split()]
     for a, b in pairwise(positions):
         assert a <= b
         fragsize = int(round((b - a) / 1000.0))  # kb

--- a/jcvi/assembly/patch.py
+++ b/jcvi/assembly/patch.py
@@ -989,8 +989,8 @@ def refine(args):
         sys.exit(not p.print_help())
 
     breakpointsbed, gapsbed = args
-    ncols = len(open(breakpointsbed).next().split())
-    logging.debug("File {0} contains {1} columns.".format(breakpointsbed, ncols))
+    ncols = len(next(open(breakpointsbed)).split())
+    logging.debug("File %s contains %d columns.", breakpointsbed, ncols)
     cmd = "intersectBed -wao -a {0} -b {1}".format(breakpointsbed, gapsbed)
 
     pf = "{0}.{1}".format(breakpointsbed.split(".")[0], gapsbed.split(".")[0])

--- a/jcvi/assembly/patch.py
+++ b/jcvi/assembly/patch.py
@@ -1032,7 +1032,7 @@ def refine(args):
         pbed = Bed()
         bed = Bed(nogapsbed)
         for b in bed:
-            pos = (b.start + b.end) / 2
+            pos = (b.start + b.end) // 2
             b.start, b.end = pos, pos
             pbed.append(b)
         pbed.print_to_file(pointbed)

--- a/jcvi/formats/vcf.py
+++ b/jcvi/formats/vcf.py
@@ -563,7 +563,7 @@ def summary(args):
     bedfw = open(opts.bed, "w") if opts.bed else None
 
     fp = open(txtfile)
-    header = fp.next().split()  # Header
+    header = next(fp).split()  # Header
     snps = defaultdict(list)  # contig => list of loci
     combinations = defaultdict(int)
     intraSNPs = interSNPs = 0

--- a/jcvi/graphics/align.py
+++ b/jcvi/graphics/align.py
@@ -220,7 +220,7 @@ class OpticalMapAlign(BaseAlign):
     def from_silico(self, filename="Ecoli.silico", nfrags=25):
         fp = open(filename)
         next(fp)
-        ar = [0] + [int(x) for x in fp.next().split()]
+        ar = [0] + [int(x) for x in next(fp).split()]
         sizes = []  # Only retain frags beyond certain size
         for a, b in pairwise(ar):
             size = b - a

--- a/jcvi/graphics/heatmap.py
+++ b/jcvi/graphics/heatmap.py
@@ -36,7 +36,7 @@ def parse_csv(csvfile, vmin=0, groups=False):
 
     reader = csv.reader(open(csvfile))
     if groups:
-        groups = reader.next()[1:]
+        groups = next(reader)[1:]
         # Fill in empty cells in groups
         filled_groups = []
         lastg = ""
@@ -47,7 +47,7 @@ def parse_csv(csvfile, vmin=0, groups=False):
         groups = filled_groups
 
     rows = []
-    cols = reader.next()[1:]
+    cols = next(reader)[1:]
     data = []
     for row in reader:
         name = row[0]
@@ -62,17 +62,25 @@ def parse_csv(csvfile, vmin=0, groups=False):
 
 def main():
     p = OptionParser(__doc__)
-    p.add_option("--groups", default=False, action="store_true",
-                 help="The first row contains group info [default: %default]")
-    p.add_option("--rowgroups", help="Row groupings [default: %default]")
-    p.add_option("--horizontalbar", default=False, action="store_true",
-                 help="Horizontal color bar [default: vertical]")
+    p.add_option(
+        "--groups",
+        default=False,
+        action="store_true",
+        help="The first row contains group info",
+    )
+    p.add_option("--rowgroups", help="Row groupings")
+    p.add_option(
+        "--horizontalbar",
+        default=False,
+        action="store_true",
+        help="Horizontal color bar [default: vertical]",
+    )
     opts, args, iopts = p.set_image_options(figsize="8x8")
 
     if len(args) != 1:
         sys.exit(not p.print_help())
 
-    datafile, = args
+    (datafile,) = args
     pf = datafile.rsplit(".", 1)[0]
     rowgroups = opts.rowgroups
 
@@ -89,16 +97,16 @@ def main():
 
     plt.rcParams["axes.linewidth"] = 0
 
-    xstart = .18
+    xstart = 0.18
     fig = plt.figure(1, (iopts.w, iopts.h))
     root = fig.add_axes([0, 0, 1, 1])
-    ax = fig.add_axes([xstart, .15, .7, .7])
+    ax = fig.add_axes([xstart, 0.15, 0.7, 0.7])
 
     im = ax.matshow(data, cmap=iopts.cmap, norm=mpl.colors.LogNorm(vmin=1, vmax=10000))
     nrows, ncols = len(rows), len(cols)
 
-    xinterval = .7 / ncols
-    yinterval = .7 / max(nrows, ncols)
+    xinterval = 0.7 / ncols
+    yinterval = 0.7 / max(nrows, ncols)
 
     plt.xticks(range(ncols), cols, rotation=45, size=10, ha="center")
     plt.yticks(range(nrows), rows, size=10)
@@ -106,42 +114,42 @@ def main():
     for x in ax.get_xticklines() + ax.get_yticklines():
         x.set_visible(False)
 
-    ax.set_xlim(-.5, ncols - .5)
+    ax.set_xlim(-0.5, ncols - 0.5)
 
     t = [1, 10, 100, 1000, 10000]
-    pad = .06
+    pad = 0.06
     if opts.horizontalbar:
-        ypos = .5 * (1 - nrows * yinterval) - pad
-        axcolor = fig.add_axes([.3, ypos, .4, .02])
+        ypos = 0.5 * (1 - nrows * yinterval) - pad
+        axcolor = fig.add_axes([0.3, ypos, 0.4, 0.02])
         orientation = "horizontal"
     else:
-        axcolor = fig.add_axes([.9, .3, .02, .4])
+        axcolor = fig.add_axes([0.9, 0.3, 0.02, 0.4])
         orientation = "vertical"
     fig.colorbar(im, cax=axcolor, ticks=t, orientation=orientation)
 
     if groups:
         groups = [(key, len(list(nn))) for key, nn in groupby(groups)]
-        yy = .5 + .5 * nrows / ncols * .7 + .06
-        e = .005
-        sep = -.5
+        yy = 0.5 + 0.5 * nrows / ncols * 0.7 + 0.06
+        e = 0.005
+        sep = -0.5
 
         for k, kl in groups:
             # Separator in the array area
             sep += kl
-            ax.plot([sep, sep], [-.5, nrows - .5], "w-", lw=2)
+            ax.plot([sep, sep], [-0.5, nrows - 0.5], "w-", lw=2)
             # Group labels on the top
             kl *= xinterval
             root.plot([xstart + e, xstart + kl - e], [yy, yy], "-", color="gray", lw=2)
-            root.text(xstart + .5 * kl, yy + e, k, ha="center", color="gray")
+            root.text(xstart + 0.5 * kl, yy + e, k, ha="center", color="gray")
             xstart += kl
 
     if rowgroups:
         from jcvi.graphics.glyph import TextCircle
 
-        xpos = .04
-        tip = .015
+        xpos = 0.04
+        tip = 0.015
         assert rgroups
-        ystart = 1 - .5 * (1 - nrows * yinterval)
+        ystart = 1 - 0.5 * (1 - nrows * yinterval)
         for gname, start, end in rgroups:
             start = ystart - start * yinterval
             end = ystart - (end + 1) * yinterval
@@ -152,7 +160,7 @@ def main():
             root.plot((xpos, xpos + tip), (start, start), "k-", lw=2)
             root.plot((xpos, xpos), (start, end), "k-", lw=2)
             root.plot((xpos, xpos + tip), (end, end), "k-", lw=2)
-            TextCircle(root, xpos, .5 * (start + end), gname)
+            TextCircle(root, xpos, 0.5 * (start + end), gname)
 
     root.set_xlim(0, 1)
     root.set_ylim(0, 1)
@@ -162,5 +170,5 @@ def main():
     savefig(image_name, dpi=iopts.dpi, iopts=iopts)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/jcvi/graphics/whisker.py
+++ b/jcvi/graphics/whisker.py
@@ -29,27 +29,30 @@ ggsave('$outfile')
 
 def main():
     p = OptionParser(__doc__)
-    p.add_option("--levels",
-                help="Reorder factors, comma-delimited [default: alphabetical]")
-    p.add_option("--notch", default=False, action="store_true",
-                 help="notched box plot [default: %default]")
-    p.add_option("--title", default=" ",
-                help="Title of the figure [default: %default]")
-    p.add_option("--xlabel", help="X-axis label [default: %default]")
-    p.add_option("--ylabel", help="Y-axis label [default: %default]")
-    p.add_option("--fontsize", default=16,
-                 help="Font size [default: %default]")
+    p.add_option(
+        "--levels", help="Reorder factors, comma-delimited [default: alphabetical]"
+    )
+    p.add_option(
+        "--notch",
+        default=False,
+        action="store_true",
+        help="notched box plot",
+    )
+    p.add_option("--title", default=" ", help="Title of the figure")
+    p.add_option("--xlabel", help="X-axis label")
+    p.add_option("--ylabel", help="Y-axis label")
+    p.add_option("--fontsize", default=16, help="Font size")
     opts, args = p.parse_args()
 
     if len(args) != 1:
         sys.exit(not p.print_help())
 
-    datafile, = args
+    (datafile,) = args
     header = open(datafile)
     levels = opts.levels
     xlabel = opts.xlabel
     ylabel = opts.ylabel
-    lx, ly = header.next().rstrip().split('\t')
+    lx, ly = next(header).rstrip().split("\t")
 
     lx = xlabel or lx
     ly = ylabel or ly
@@ -61,5 +64,5 @@ def main():
     rtemplate.run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/jcvi/projects/tgbs.py
+++ b/jcvi/projects/tgbs.py
@@ -184,7 +184,7 @@ def mstmap(args):
     fp = open(lmd)
     next(fp)  # Header
     table = {"0": "-", "1": "A", "2": "B", "3": "X"}
-    mh = ["locus_name"] + fp.next().split()[4:]
+    mh = ["locus_name"] + next(fp).split()[4:]
     genotypes = []
     for row in fp:
         atoms = row.split()

--- a/jcvi/variation/delly.py
+++ b/jcvi/variation/delly.py
@@ -160,7 +160,7 @@ def mitocompile(args):
             logging.debug("Process `{}` [{}]".format(vcf, percentage(i + 1, len(vcfs))))
         depthfile = vcf.replace(".sv.vcf.gz", ".depth")
         fp = must_open(depthfile)
-        chrm, depth = fp.next().split()
+        _, depth = next(fp).split()
         depth = int(float(depth))
         samplekey = op.basename(vcf).split("_")[0]
 


### PR DESCRIPTION
We failed to convert all instances of `.next()` to `next()` during our Python 2 to Python 3 upgrade, which lead to #363.

Converted residual instances that we could find. Also drive-by fixed an issue where `Queue()` did not work properly on macOS.