### PR TITLE
Sanitize display strings with latex() (thanks @goeckeritz, #21)

### DIFF
--- a/jcvi/compara/synteny.py
+++ b/jcvi/compara/synteny.py
@@ -1717,6 +1717,7 @@ def depth(args):
     multiplicity will be summarized to stderr.
     """
     from jcvi.utils.range import range_depth
+    from jcvi.graphics.base import latex
 
     p = OptionParser(depth.__doc__)
     p.add_option("--depthfile", help="Generate file with gene and depth")
@@ -1805,7 +1806,7 @@ def depth(args):
         qgenome, sgenome, speak, qpeak
     )
     root = f.add_axes([0, 0, 1, 1])
-    vs, pattern = title.split("\n")
+    vs, pattern = latex(title).split("\n")
     root.text(0.5, 0.97, vs, ha="center", va="center", color="darkslategray")
     root.text(0.5, 0.925, pattern, ha="center", va="center", color="tomato", size=16)
     print(title, file=sys.stderr)

--- a/jcvi/graphics/base.py
+++ b/jcvi/graphics/base.py
@@ -194,6 +194,16 @@ def load_image(filename):
 
 
 def latex(s):
+    """Latex doesn't work well with certain characters, like '_', in plain text.
+    These characters would be interpreted as control characters, so we sanitize
+    these strings.
+
+    Args:
+        s (str): Input string
+
+    Returns:
+        str: Output string sanitized
+    """
     return "".join([CHARS.get(char, char) for char in s])
 
 

--- a/tests/graphics/test_base.py
+++ b/tests/graphics/test_base.py
@@ -19,3 +19,15 @@ def test_shorten(s, expected):
     from jcvi.graphics.base import shorten
 
     assert shorten(s) == expected, "Expect {}".format(expected)
+
+
+@pytest.mark.parametrize(
+    "s,expected",
+    [
+        ("grape_grape vs peach_peach", "grape\_grape vs peach\_peach"),
+    ],
+)
+def test_latex(s, expected):
+    from jcvi.graphics.base import latex
+
+    assert latex(s) == expected, "Expect {}".format(expected)


### PR DESCRIPTION
Latex doesn't work well with certain input characters, like '_', so we need to sanitize strings in `compara.synteny.depth()`.