### PR TITLE
Use op.basename when inferring blastfile prefix

### DIFF
--- a/jcvi/compara/catalog.py
+++ b/jcvi/compara/catalog.py
@@ -672,8 +672,8 @@ def ortholog(args):
     minsize_flag = "--min_size={}".format(opts.n)
     cpus_flag = "--cpus={}".format(opts.cpus)
 
-    aprefix = afasta.split(".")[0]
-    bprefix = bfasta.split(".")[0]
+    aprefix = op.basename(a)
+    bprefix = op.basename(b)
     pprefix = ".".join((aprefix, bprefix))
     qprefix = ".".join((bprefix, aprefix))
     last = pprefix + ".last"

--- a/tests/compara/test_synteny.py
+++ b/tests/compara/test_synteny.py
@@ -18,3 +18,23 @@ def test_get_orientation(ia, ib, expected):
     from jcvi.compara.synteny import get_orientation
 
     assert get_orientation(ia, ib) == expected
+
+
+@pytest.mark.parametrize(
+    "hintfile,bed_filenames",
+    [
+        ("grape.peach.last", ("grape.bed", "peach.bed")),
+        ("./grape.peach.last", ("./grape.bed", "./peach.bed")),
+        (
+            "../../test/opt/grape.peach.last",
+            ("../../test/opt/grape.bed", "../../test/opt/peach.bed"),
+        ),
+    ],
+)
+def test_get_bed_filenames(hintfile, bed_filenames):
+    from types import SimpleNamespace
+    from jcvi.compara.synteny import get_bed_filenames
+
+    opts = SimpleNamespace()
+    opts.qbed, opts.sbed = None, None
+    assert get_bed_filenames(hintfile, None, opts) == bed_filenames


### PR DESCRIPTION
Correctly handle relative path in argument, per #389 