### PR TITLE
Update biomart.py

### DIFF
--- a/jcvi/apps/biomart.py
+++ b/jcvi/apps/biomart.py
@@ -66,7 +66,7 @@ class PhytozomePath(dict):
         else:
             self.name = element.attrib["name"]
         self.tag = tag
-        for child in element.getchildren():
+        for child in list(element):
             if child.tag not in self.TAGS_OF_INTEREST:
                 continue
             child = PhytozomePath(child)


### PR DESCRIPTION
In python xml.etree.ElementTree module,
getchildren(),
Deprecated since version 3.2, will be removed in version 3.9: Use list(elem) or iteration.