### PR TITLE
Fix issue when writing "FLIP" in tour (thanks @jguppy, #456)

### DIFF
--- a/jcvi/assembly/allmaps.py
+++ b/jcvi/assembly/allmaps.py
@@ -171,7 +171,7 @@ class ScaffoldOO(object):
         print_tour(fwtour, self.object, tag, "INIT", tour, recode=True)
         signs = self.assign_orientation()
         assert len(signs) == len(scaffolds)
-        tour = zip(scaffolds, signs)
+        tour = list(zip(scaffolds, signs))
         scaffolds_oo = dict(tour)
         print_tour(fwtour, self.object, tag, "FLIP", tour, recode=True)
         tour = self.assign_order()
@@ -1100,7 +1100,7 @@ def movie(args):
     sizes = Sizes(scaffoldsfasta).mapping
     ffmpeg = "ffmpeg"
     mkdir(ffmpeg)
-    score = cur_score = None
+    score = None
     i = 1
     for header, block in read_block(fp, ">"):
         s, tag, label = header[1:].split()
@@ -1985,6 +1985,7 @@ def plot(args):
         while height / len(ax.get_yticks()) < 0.03 and len(ax.get_yticks()) >= 2:
             ax.set_yticks(ax.get_yticks()[::2])  # Sparsify the ticks
         yticklabels = [int(x) for x in ax.get_yticks()]
+        ax.set_yticks(yticklabels)
         ax.set_yticklabels(yticklabels, family="Helvetica")
         if rho < 0:
             ax.invert_yaxis()

--- a/jcvi/assembly/allmaps.py
+++ b/jcvi/assembly/allmaps.py
@@ -171,7 +171,7 @@ class ScaffoldOO(object):
         print_tour(fwtour, self.object, tag, "INIT", tour, recode=True)
         signs = self.assign_orientation()
         assert len(signs) == len(scaffolds)
-        tour = list(zip(scaffolds, signs))
+        tour = zip(scaffolds, signs)
         scaffolds_oo = dict(tour)
         print_tour(fwtour, self.object, tag, "FLIP", tour, recode=True)
         tour = self.assign_order()
@@ -1355,7 +1355,7 @@ def print_tour(fw, object, tag, label, tour, recode=False):
         tour = recode_tour(tour)
     if fw:
         print(">{0} ({1}) {2}".format(object, tag, label), file=fw)
-        print(" ".join("".join(x) for x in tour), file=fw)
+        print(" ".join("".join(x) for x in list(tour)), file=fw)
 
 
 def recode_tour(tour):


### PR DESCRIPTION
This is a regression introduced when we migrated from py2 to py3. `zip()` is an iterator object in py3 vs a list in py2. So in this particular case when `FLIP` configuration is written, the iterator is no longer valid, leaving an empty list. Fixed by converting to an actual list instead.