### PR TITLE
Add --seed in graphics options

### DIFF
--- a/jcvi/apps/base.py
+++ b/jcvi/apps/base.py
@@ -24,6 +24,7 @@ from configparser import (
 from socket import gethostname
 from subprocess import PIPE, call, check_call
 from optparse import OptionParser as OptionP, OptionGroup, SUPPRESS_HELP
+from typing import Any, Collection, List, Optional
 
 from natsort import natsorted
 from rich.logging import Console, RichHandler
@@ -511,6 +512,7 @@ class OptionParser(OptionP):
         font="Helvetica",
         style="darkgrid",
         cmap="jet",
+        seed=None,
     ):
         """
         Add image format options for given command line programs.
@@ -564,6 +566,12 @@ class OptionParser(OptionP):
         group.add_option("--cmap", default=cmap, help="Use this color map")
         group.add_option(
             "--notex", default=False, action="store_true", help="Do not use tex"
+        )
+        group.add_option(
+            "--seed",
+            default=None,
+            type="int",
+            help="Random seed when assigning colors (supported only for some plots)",
         )
 
         if args is None:
@@ -2225,7 +2233,7 @@ def inspect(object):
         print("{}: {}".format(k, details), file=sys.stderr)
 
 
-def sample_N(a, N, seed=None):
+def sample_N(a: Collection[Any], N: int, seed: Optional[int] = None) -> List[Any]:
     """When size of N is > size of a, random.sample() will emit an error:
     ValueError: sample larger than population
 

--- a/jcvi/apps/base.py
+++ b/jcvi/apps/base.py
@@ -512,7 +512,7 @@ class OptionParser(OptionP):
         font="Helvetica",
         style="darkgrid",
         cmap="jet",
-        seed=None,
+        seed: Optional[int] = None,
     ):
         """
         Add image format options for given command line programs.
@@ -569,7 +569,7 @@ class OptionParser(OptionP):
         )
         group.add_option(
             "--seed",
-            default=None,
+            default=seed,
             type="int",
             help="Random seed when assigning colors (supported only for some plots)",
         )

--- a/jcvi/apps/ks.py
+++ b/jcvi/apps/ks.py
@@ -12,6 +12,7 @@ import sys
 from functools import partial
 from itertools import combinations, product
 from math import exp, log, pi, sqrt
+from typing import Optional
 
 import numpy as np
 from Bio import AlignIO, SeqIO
@@ -155,7 +156,7 @@ class LayoutLine(object):
 
 
 class Layout(AbstractLayout):
-    def __init__(self, filename, delimiter=","):
+    def __init__(self, filename, delimiter=",", seed: Optional[int] = None):
         super(Layout, self).__init__(filename)
         if not op.exists(filename):
             ksfiles = iglob(".", "*.ks")
@@ -174,8 +175,8 @@ class Layout(AbstractLayout):
                 continue
             self.append(LayoutLine(row, delimiter=delimiter))
 
-        self.assign_colors()
-        self.assign_markers()
+        self.assign_colors(seed=seed)
+        self.assign_markers(seed=seed)
 
 
 class KsPlot(object):
@@ -288,7 +289,7 @@ def multireport(args):
     ks_max = opts.vmax
     bins = opts.bins
     fill = opts.fill
-    layout = Layout(layoutfile)
+    layout = Layout(layoutfile, seed=iopts.seed)
     print(layout, file=sys.stderr)
 
     fig = plt.figure(1, (iopts.w, iopts.h))

--- a/jcvi/graphics/base.py
+++ b/jcvi/graphics/base.py
@@ -74,6 +74,7 @@ class ImageOptions(object):
         self.dpi = opts.dpi
         self.format = opts.format
         self.cmap = cm.get_cmap(opts.cmap)
+        self.seed = opts.seed
         self.opts = opts
 
     def __str__(self):
@@ -137,17 +138,17 @@ class AbstractLayout(LineFile):
             if not getattr(x, attrib):
                 setattr(x, attrib, c)
 
-    def assign_colors(self):
+    def assign_colors(self, seed=None):
         number = len(self)
         palette = set2_n if number <= 8 else set3_n
         # Restrict palette numbers between [3, 12]
         palette_number = max(3, min(number, 12))
         colorset = palette(palette_number)
-        colorset = sample_N(colorset, number)
+        colorset = sample_N(colorset, number, seed=seed)
         self.assign_array("color", colorset)
 
-    def assign_markers(self):
-        markerset = sample_N(mpl.lines.Line2D.filled_markers, len(self))
+    def assign_markers(self, seed=None):
+        markerset = sample_N(mpl.lines.Line2D.filled_markers, len(self), seed=seed)
         self.assign_array("marker", markerset)
 
     def __str__(self):
@@ -235,7 +236,7 @@ def set2_n(number=8):
     # Get Set2 from ColorBrewer, a set of colors deemed colorblind-safe and
     # pleasant to look at by Drs. Cynthia Brewer and Mark Harrower of Pennsylvania
     # State University. These colors look lovely together, and are less
-    # saturated than those colors in Set1. For more on ColorBrewer, see:
+    # saturated than those colors in Set1.
     return get_map("Set2", "qualitative", number).hex_colors
 
 

--- a/jcvi/graphics/base.py
+++ b/jcvi/graphics/base.py
@@ -33,6 +33,7 @@ from matplotlib.patches import (
     FancyBboxPatch,
 )
 from matplotlib.path import Path
+from typing import Optional
 
 from jcvi.formats.base import LineFile
 from jcvi.apps.base import glob, listify, datadir, sample_N, which
@@ -138,7 +139,7 @@ class AbstractLayout(LineFile):
             if not getattr(x, attrib):
                 setattr(x, attrib, c)
 
-    def assign_colors(self, seed=None):
+    def assign_colors(self, seed: Optional[int] = None):
         number = len(self)
         palette = set2_n if number <= 8 else set3_n
         # Restrict palette numbers between [3, 12]

--- a/jcvi/graphics/base.py
+++ b/jcvi/graphics/base.py
@@ -148,7 +148,7 @@ class AbstractLayout(LineFile):
         colorset = sample_N(colorset, number, seed=seed)
         self.assign_array("color", colorset)
 
-    def assign_markers(self, seed=None):
+    def assign_markers(self, seed: Optional[int] = None):
         markerset = sample_N(mpl.lines.Line2D.filled_markers, len(self), seed=seed)
         self.assign_array("marker", markerset)
 

--- a/jcvi/graphics/chromosome.py
+++ b/jcvi/graphics/chromosome.py
@@ -563,7 +563,7 @@ def draw_chromosomes(
     ncolors = max(3, min(len(classes), 12))
     palette = set1_n if ncolors <= 8 else set3_n
     colorset = palette(number=ncolors)
-    colorset = sample_N(colorset, len(classes))
+    colorset = sample_N(colorset, len(classes), seed=iopts.seed)
     class_colors = dict(zip(classes, colorset))
     class_colors.update(preset_colors)
     logging.debug("Assigned colors: {}".format(class_colors))

--- a/jcvi/graphics/dotplot.py
+++ b/jcvi/graphics/dotplot.py
@@ -276,6 +276,7 @@ def dotplot(
         logging.debug("Capping values within [{0:.1f}, {1:.1f}]".format(vmin, vmax))
 
     block_id = 0
+    block_color = "k"
     for row in fp:
         atoms = row.split()
         if row[0] == "#":

--- a/jcvi/graphics/karyotype.py
+++ b/jcvi/graphics/karyotype.py
@@ -23,6 +23,8 @@ e, 0, 1, athaliana.grape.4x1.simple
 import sys
 import logging
 
+from typing import Optional
+
 from jcvi.apps.base import OptionParser
 from jcvi.compara.synteny import SimpleFile
 from jcvi.formats.bed import Bed
@@ -58,7 +60,9 @@ class LayoutLine(object):
 
 
 class Layout(AbstractLayout):
-    def __init__(self, filename, delimiter=",", generank=False, seed=None):
+    def __init__(
+        self, filename, delimiter=",", generank=False, seed: Optional[int] = None
+    ):
         super(Layout, self).__init__(filename)
         fp = open(filename)
         self.edges = []
@@ -349,7 +353,7 @@ class Karyotype(object):
         plot_label=True,
         plot_circles=True,
         shadestyle="curve",
-        seed=None,
+        seed: Optional[int] = None,
     ):
         layout = Layout(layoutfile, generank=generank, seed=seed)
 

--- a/jcvi/graphics/karyotype.py
+++ b/jcvi/graphics/karyotype.py
@@ -58,7 +58,7 @@ class LayoutLine(object):
 
 
 class Layout(AbstractLayout):
-    def __init__(self, filename, delimiter=",", generank=False):
+    def __init__(self, filename, delimiter=",", generank=False, seed=None):
         super(Layout, self).__init__(filename)
         fp = open(filename)
         self.edges = []
@@ -80,7 +80,7 @@ class Layout(AbstractLayout):
             else:
                 self.append(LayoutLine(row, delimiter=delimiter, generank=generank))
 
-        self.assign_colors()
+        self.assign_colors(seed=seed)
 
     def parse_blocks(self, simplefile, i):
         order = self[i].order
@@ -349,8 +349,9 @@ class Karyotype(object):
         plot_label=True,
         plot_circles=True,
         shadestyle="curve",
+        seed=None,
     ):
-        layout = Layout(layoutfile, generank=generank)
+        layout = Layout(layoutfile, generank=generank, seed=seed)
 
         fp = open(seqidsfile)
         # Strip the reverse orientation tag for e.g. chr3-
@@ -450,6 +451,7 @@ def main():
         plot_circles=(not opts.nocircles),
         shadestyle=opts.shadestyle,
         generank=(not opts.basepair),
+        seed=iopts.seed,
     )
 
     root.set_xlim(0, 1)

--- a/jcvi/graphics/synteny.py
+++ b/jcvi/graphics/synteny.py
@@ -82,7 +82,7 @@ class LayoutLine(object):
 
 
 class Layout(AbstractLayout):
-    def __init__(self, filename, delimiter=","):
+    def __init__(self, filename, delimiter=",", seed: Optional[int] = None):
         super(Layout, self).__init__(filename)
         fp = open(filename)
         self.edges = []
@@ -107,7 +107,7 @@ class Layout(AbstractLayout):
             else:
                 self.append(LayoutLine(row, delimiter=delimiter))
 
-        self.assign_colors()
+        self.assign_colors(seed=seed)
 
 
 class Shade(object):
@@ -387,12 +387,13 @@ class Synteny(object):
         shadestyle="curve",
         glyphstyle="arrow",
         glyphcolor: BasePalette = OrientationPalette(),
+        seed: Optional[int] = None,
     ):
         _, h = fig.get_figwidth(), fig.get_figheight()
         bed = Bed(bedfile)
         order = bed.order
         bf = BlockFile(datafile)
-        self.layout = lo = Layout(layoutfile)
+        self.layout = lo = Layout(layoutfile, seed=seed)
         switch = DictFile(switch, delimiter="\t") if switch else None
         if extra_features:
             extra_features = Bed(extra_features)
@@ -637,6 +638,7 @@ def main():
         shadestyle=opts.shadestyle,
         glyphstyle=opts.glyphstyle,
         glyphcolor=opts.glyphcolor,
+        seed=iopts.seed,
     )
 
     root.set_xlim(0, 1)


### PR DESCRIPTION
Some plots (`karyotype`, `chromosome`, `ks`, `synteny`) randomly assign colors when not specified.
This PR adds a `--seed` so that we can get stable colors for pubs.