### PR TITLE
Remove file shredder

### DIFF
--- a/jcvi/algorithms/lpsolve.py
+++ b/jcvi/algorithms/lpsolve.py
@@ -25,9 +25,7 @@ The input lp_data is assumed in .lp format, see below
 [0, 1]
 """
 import logging
-import os
 import os.path as op
-import shutil
 
 from dataclasses import dataclass
 from io import StringIO
@@ -219,7 +217,7 @@ class AbstractMIPSolver(object):
         raise NotImplementedError
 
     def cleanup(self):
-        shutil.rmtree(self.work_dir)
+        cleanup(self.work_dir)
 
 
 class GLPKSolver(AbstractMIPSolver):

--- a/jcvi/algorithms/tsp.py
+++ b/jcvi/algorithms/tsp.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from itertools import combinations
 from more_itertools import pairwise
 
-from jcvi.formats.base import FileShredder, must_open
+from jcvi.formats.base import must_open
 from jcvi.apps.base import cleanup, mkdir, sh, which
 
 
@@ -157,7 +157,7 @@ class Concorde(object):
         if clean:
             shutil.rmtree(work_dir)
             residual_output = ["data.sol", "data.res", "Odata.res"]
-            FileShredder(residual_output, verbose=False)
+            cleanup(residual_output)
 
     def print_to_tsplib(self, tspfile, precision=0):
         """

--- a/jcvi/algorithms/tsp.py
+++ b/jcvi/algorithms/tsp.py
@@ -7,9 +7,7 @@ algorithms.lpsolve.tsp(). See also:
 https://developers.google.com/optimization/routing/tsp
 """
 import os.path as op
-import os
 import logging
-import shutil
 import numpy as np
 
 from collections import defaultdict
@@ -155,7 +153,7 @@ class Concorde(object):
         self.tour = self.parse_output(outfile)
 
         if clean:
-            shutil.rmtree(work_dir)
+            cleanup(work_dir)
             residual_output = ["data.sol", "data.res", "Odata.res"]
             cleanup(residual_output)
 

--- a/jcvi/annotation/automaton.py
+++ b/jcvi/annotation/automaton.py
@@ -6,7 +6,6 @@ Automate genome annotation by iterating processing a set of files, individually.
 """
 
 import os.path as op
-import shutil
 import sys
 import logging
 
@@ -16,7 +15,15 @@ from tempfile import mkdtemp
 from jcvi.assembly.automaton import iter_project
 from jcvi.apps.grid import Jobs, MakeManager
 from jcvi.formats.base import FileMerger, split
-from jcvi.apps.base import OptionParser, ActionDispatcher, need_update, mkdir, sh, iglob
+from jcvi.apps.base import (
+    ActionDispatcher,
+    OptionParser,
+    cleanup,
+    iglob,
+    mkdir,
+    need_update,
+    sh,
+)
 
 
 def main():
@@ -89,7 +96,7 @@ def augustus(args):
     gff3files = [x.rsplit(".", 1)[0] + suffix for x in fs.names]
     outfile = fastafile.rsplit(".", 1)[0] + suffix
     FileMerger(gff3files, outfile=outfile).merge()
-    shutil.rmtree(outdir)
+    cleanup(outdir)
 
     if gff3:
         from jcvi.annotation.reformat import augustus as reformat_augustus

--- a/jcvi/annotation/evm.py
+++ b/jcvi/annotation/evm.py
@@ -85,7 +85,8 @@ def maker(args):
 
     Prepare EVM inputs by separating tracks from MAKER.
     """
-    from jcvi.formats.base import SetFile, FileShredder
+    from jcvi.formats.base import SetFile
+    from jcvi.apps.base import cleanup
 
     A, T, P = "ABINITIO_PREDICTION", "TRANSCRIPT", "PROTEIN"
     # Stores default weights and types
@@ -130,7 +131,7 @@ def maker(args):
     write_file(weightsfile, contents)
 
     evs = [x + ".gff" for x in (A, T, P)]
-    FileShredder(evs)
+    cleanup(evs)
 
     for type, tracks in reg.items():
         for t in tracks:

--- a/jcvi/annotation/reformat.py
+++ b/jcvi/annotation/reformat.py
@@ -1074,7 +1074,6 @@ def reindex(args):
     from jcvi.formats.gff import make_index
     from jcvi.formats.fasta import Fasta
     from jcvi.apps.emboss import needle
-    from jcvi.formats.base import FileShredder
     from tempfile import mkstemp
 
     p = OptionParser(reindex.__doc__)
@@ -1167,7 +1166,7 @@ def reindex(args):
     if not opts.scores:
         fw.close()
         needle([pairsfile, refpep, pep])
-        FileShredder([pairsfile], verbose=False)
+        cleanup(pairsfile)
         scoresfile = "{0}.scores".format(pairsfile.rsplit(".")[0])
     else:
         scoresfile = opts.scores

--- a/jcvi/apps/base.py
+++ b/jcvi/apps/base.py
@@ -1278,7 +1278,7 @@ def mkdir(dirname, overwrite=False):
     """
     if op.isdir(dirname):
         if overwrite:
-            shutil.rmtree(dirname)
+            cleanup(dirname)
             os.mkdir(dirname)
             logging.debug("Overwrite folder `{0}`.".format(dirname))
         else:

--- a/jcvi/apps/base.py
+++ b/jcvi/apps/base.py
@@ -1450,7 +1450,7 @@ def download(
     if op.exists(final_filename):
         if debug:
             msg = "File `{}` exists. Download skipped.".format(final_filename)
-            logging.error(msg)
+            logging.info(msg)
         success = True
     else:
         from jcvi.utils.ez_setup import get_best_downloader

--- a/jcvi/apps/bwa.py
+++ b/jcvi/apps/bwa.py
@@ -12,16 +12,16 @@ import sys
 import logging
 
 from jcvi.formats.sam import output_bam, get_samfile, mapped
-from jcvi.formats.base import FileShredder
 from jcvi.assembly.automaton import iter_project
 from jcvi.apps.grid import MakeManager
 from jcvi.apps.base import (
-    OptionParser,
     ActionDispatcher,
-    need_update,
-    sh,
+    OptionParser,
+    cleanup,
     get_abs_path,
     mkdir,
+    need_update,
+    sh,
 )
 
 
@@ -181,7 +181,7 @@ def align(args):
         if not bam:
             mopts += ["--sam"]
         mapped(mopts)
-        FileShredder([samfile])
+        cleanup(samfile)
 
     return samfile, None
 

--- a/jcvi/apps/emboss.py
+++ b/jcvi/apps/emboss.py
@@ -7,8 +7,8 @@ Run EMBOSS programs.
 import sys
 import multiprocessing as mp
 
-from jcvi.apps.base import OptionParser, ActionDispatcher
-from jcvi.formats.base import FileShredder, must_open
+from jcvi.apps.base import ActionDispatcher, OptionParser, cleanup
+from jcvi.formats.base import must_open
 
 
 class NeedleHeader(object):
@@ -42,7 +42,7 @@ def _needle(fa, fb, needlefile, a, b, results):
     )
     _, _ = needle_cline()
     nh = NeedleHeader(needlefile)
-    FileShredder([fa, fb, needlefile], verbose=False)
+    cleanup(fa, fb, needlefile)
     r = ["\t".join((a, b, nh.identity, nh.score))]
 
     results.extend(r)

--- a/jcvi/apps/fetch.py
+++ b/jcvi/apps/fetch.py
@@ -14,20 +14,21 @@ from urllib.error import HTTPError, URLError
 from Bio import Entrez, SeqIO
 from more_itertools import grouper
 
-from jcvi.formats.base import FileShredder, must_open
+from jcvi.formats.base import must_open
 from jcvi.formats.fasta import print_first_difference
 from jcvi.formats.fastq import fromsra
 from jcvi.utils.cbook import tile
 from jcvi.utils.console import printf
 from jcvi.apps.base import (
-    OptionParser,
     ActionDispatcher,
-    get_email_address,
-    mkdir,
-    ls_ftp,
+    OptionParser,
+    cleanup,
     download,
-    sh,
+    get_email_address,
     last_updated,
+    ls_ftp,
+    mkdir,
+    sh,
     which,
 )
 
@@ -258,7 +259,7 @@ def phytozome(args):
     cookies = get_cookies()
     if cookies is None:
         logging.error("Error fetching cookies ... cleaning up")
-        FileShredder([directory_listing])
+        cleanup(directory_listing)
         sys.exit(1)
 
     # Proceed to use the cookies and download the species list
@@ -272,7 +273,7 @@ def phytozome(args):
         g = GlobusXMLParser(directory_listing)
     except:
         logging.error("Error downloading directory listing ... cleaning up")
-        FileShredder([directory_listing, cookies])
+        cleanup(directory_listing, cookies)
         sys.exit(1)
 
     genomes = g.get_genomes()

--- a/jcvi/apps/uclust.py
+++ b/jcvi/apps/uclust.py
@@ -8,7 +8,6 @@ The VCLUST implementation borrows ideas and code from PyRAD. PyRAD link:
 <https://github.com/dereneaton/pyrad>
 """
 import os.path as op
-import shutil
 import sys
 import logging
 import numpy as np
@@ -32,10 +31,11 @@ from jcvi.utils.table import write_csv
 from jcvi.apps.base import (
     OptionParser,
     ActionDispatcher,
+    cleanup,
     datadir,
+    iglob,
     listify,
     mkdir,
-    iglob,
     need_update,
     sh,
 )
@@ -862,7 +862,7 @@ def parallel_musclewrap(clustfile, cpus, minsamp=0):
     clustnames = [x.replace(".clust", ".clustS") for x in fs.names]
     clustSfile = clustfile.replace(".clust", ".clustS")
     FileMerger(clustnames, outfile=clustSfile).merge()
-    shutil.rmtree(outdir)
+    cleanup(outdir)
 
 
 def filter_samples(names, seqs, sep="."):

--- a/jcvi/assembly/allmaps.py
+++ b/jcvi/assembly/allmaps.py
@@ -27,7 +27,7 @@ from jcvi.algorithms.tsp import hamiltonian
 from jcvi.algorithms.matrix import determine_signs
 from jcvi.algorithms.ec import GA_setup, GA_run
 from jcvi.formats.agp import AGP, order_to_agp, build as agp_build, reindex
-from jcvi.formats.base import DictFile, FileMerger, FileShredder, must_open, read_block
+from jcvi.formats.base import DictFile, FileMerger, must_open, read_block
 from jcvi.formats.bed import Bed, BedLine, natsorted, sort
 from jcvi.formats.chain import fromagp
 from jcvi.formats.sizes import Sizes
@@ -36,15 +36,16 @@ from jcvi.utils.cbook import human_size, percentage
 from jcvi.utils.grouper import Grouper
 from jcvi.utils.table import tabulate
 from jcvi.apps.base import (
-    OptionParser,
-    OptionGroup,
     ActionDispatcher,
-    flatten,
-    sh,
-    need_update,
-    get_today,
+    OptionGroup,
+    OptionParser,
     SUPPRESS_HELP,
+    cleanup,
+    flatten,
+    get_today,
     mkdir,
+    need_update,
+    sh,
 )
 
 
@@ -1783,16 +1784,14 @@ def build(args):
         sh(cmd, check=True)
 
     if opts.cleanup:
-        FileShredder(
-            [
-                chr_fasta,
-                unplaced_fasta,
-                combined_fasta,
-                chainfile,
-                unplaced_agp,
-                combined_fasta + ".sizes",
-                "unmapped",
-            ]
+        cleanup(
+            chr_fasta,
+            unplaced_fasta,
+            combined_fasta,
+            chainfile,
+            unplaced_agp,
+            combined_fasta + ".sizes",
+            "unmapped",
         )
 
     sort([liftedbed, "-i"])  # Sort bed in place

--- a/jcvi/assembly/patch.py
+++ b/jcvi/assembly/patch.py
@@ -41,8 +41,8 @@ from jcvi.utils.range import (
     range_closest,
     range_interleave,
 )
-from jcvi.formats.base import FileMerger, FileShredder
-from jcvi.apps.base import OptionParser, ActionDispatcher, sh
+from jcvi.formats.base import FileMerger
+from jcvi.apps.base import ActionDispatcher, OptionParser, cleanup, sh
 
 
 def main():
@@ -411,7 +411,7 @@ def insert(args):
 
     # Clean-up
     toclean = [gpbedfile, agpfile, maskedagpfile, maskedbedfile]
-    FileShredder(toclean)
+    cleanup(toclean)
 
 
 def gaps(args):
@@ -880,7 +880,7 @@ def refine(args):
     FileMerger(beds, outfile=refinedbed).merge()
 
     # Clean-up
-    FileShredder(toclean)
+    cleanup(toclean)
 
     return refinedbed
 

--- a/jcvi/assembly/preprocess.py
+++ b/jcvi/assembly/preprocess.py
@@ -180,7 +180,7 @@ def expand(args):
     from jcvi.formats.fasta import Fasta, SeqIO
     from jcvi.formats.fastq import readlen, first, fasta
     from jcvi.formats.blast import Blast
-    from jcvi.formats.base import FileShredder
+    from jcvi.apps.base import cleanup
     from jcvi.apps.bowtie import align, get_samfile
     from jcvi.apps.align import blast
 
@@ -251,7 +251,7 @@ def expand(args):
     SeqIO.write(recs, fw, "fasta")
     fw.close()
 
-    FileShredder([samfile, logfile, mapped, reads, fastafile, qualfile, blastfile, pf])
+    cleanup(samfile, logfile, mapped, reads, fastafile, qualfile, blastfile, pf)
     logging.debug(
         "Annotated seqs (n={0}) written to `{1}`.".format(len(recs), annotatedfasta)
     )

--- a/jcvi/assembly/sim.py
+++ b/jcvi/assembly/sim.py
@@ -7,13 +7,12 @@ Simulate Illumina sequencing reads.
 import os
 import os.path as op
 import random
-import shutil
 import sys
 import logging
 import math
 
 from jcvi.formats.fasta import Fasta
-from jcvi.apps.base import OptionParser, ActionDispatcher, sh
+from jcvi.apps.base import ActionDispatcher, OptionParser, cleanup, sh
 
 
 def main():
@@ -149,7 +148,7 @@ def eagle(args):
     os.chdir(cwd)
 
     # Clean-up
-    shutil.rmtree(eagle_dir)
+    cleanup(eagle_dir)
 
 
 def wgsim(args):

--- a/jcvi/compara/synteny.py
+++ b/jcvi/compara/synteny.py
@@ -20,7 +20,7 @@ from jcvi.formats.base import BaseFile, SetFile, read_block, must_open
 from jcvi.utils.grouper import Grouper
 from jcvi.utils.cbook import gene_name, human_size
 from jcvi.utils.range import Range, range_chain
-from jcvi.apps.base import OptionParser, ActionDispatcher
+from jcvi.apps.base import ActionDispatcher, OptionParser, cleanup
 
 
 class AnchorFile(BaseFile):
@@ -796,7 +796,7 @@ def assemble(args):
             print("\t".join(slots), file=fw)
 
     # Cleanup
-    shutil.rmtree(workdir)
+    cleanup(workdir)
 
 
 def colinear_evaluate_weights(tour, data):

--- a/jcvi/formats/base.py
+++ b/jcvi/formats/base.py
@@ -130,18 +130,6 @@ class SetFile(BaseFile, set):
             self.update(keys)
 
 
-class FileShredder(object):
-    """
-    Same as rm -f *
-    """
-
-    def __init__(self, filelist, verbose=True):
-
-        filelist = [x for x in filelist if x and op.exists(x)]
-        cmd = "rm -rf {0}".format(" ".join(filelist))
-        sh(cmd, log=verbose)
-
-
 class FileMerger(object):
     """
     Same as cat * > filename
@@ -1125,7 +1113,7 @@ def subset(args):
             print(ss[0].join(files[0][key]), file=fw)
 
     if nargs > 2:
-        FileShredder([file2])
+        cleanup(file2)
 
 
 def setop(args):

--- a/jcvi/formats/genbank.py
+++ b/jcvi/formats/genbank.py
@@ -13,10 +13,10 @@ from collections import defaultdict
 
 from Bio import SeqIO
 
-from jcvi.formats.base import must_open, FileShredder, BaseFile, get_number
+from jcvi.formats.base import BaseFile, get_number, must_open
 from jcvi.formats.gff import GffLine
 from jcvi.apps.fetch import entrez
-from jcvi.apps.base import OptionParser, ActionDispatcher, sh, mkdir, glob
+from jcvi.apps.base import ActionDispatcher, OptionParser, cleanup, glob, mkdir, sh
 
 
 MT = "mol_type"
@@ -277,7 +277,7 @@ class GenBank(dict):
             GenBank.write_genes_fasta(rec, fwcds, fwpep)
 
         if not pep:
-            FileShredder([fwpep.name])
+            cleanup(fwpep.name)
 
     def write_fasta(self, output="gbfasta", individual=False):
         if not individual:

--- a/jcvi/projects/heterosis.py
+++ b/jcvi/projects/heterosis.py
@@ -94,7 +94,7 @@ def mergeclean(args):
     formats.sam.merge() several times.
     """
     from itertools import groupby
-    from jcvi.formats.base import FileShredder
+    from jcvi.apps.base import cleanup
 
     p = OptionParser(mergeclean.__doc__)
     p.set_sep(sep="_", help="Separator to group per prefix")
@@ -114,7 +114,7 @@ def mergeclean(args):
         newest_f = max(fs, key=mtime)
         print("|".join(fs), "=>", newest_f, file=sys.stderr)
         fs.remove(newest_f)
-        FileShredder(fs)
+        cleanup(fs)
 
 
 def merge_counts(ss, outfile):

--- a/jcvi/projects/str.py
+++ b/jcvi/projects/str.py
@@ -9,7 +9,6 @@ import os
 import csv
 import sys
 import logging
-import shutil
 import json
 import numpy as np
 import pandas as pd
@@ -45,7 +44,7 @@ from jcvi.apps.grid import Parallel
 from jcvi.apps.bwa import align
 from jcvi.apps.base import datafile, sh
 from jcvi.assembly.sim import eagle, wgsim
-from jcvi.apps.base import OptionParser, ActionDispatcher, mkdir, iglob
+from jcvi.apps.base import ActionDispatcher, OptionParser, cleanup, iglob, mkdir
 
 
 # Huntington risk allele
@@ -1587,7 +1586,7 @@ def simulate(args):
         sh("mv {}.bai ../{}.bam.bai".format(indexed_samfile, pf))
 
         os.chdir(cwd)
-        shutil.rmtree(pf)
+        cleanup(pf)
 
     os.chdir(basecwd)
 

--- a/jcvi/variation/cnv.py
+++ b/jcvi/variation/cnv.py
@@ -1159,10 +1159,9 @@ def cn(args):
             push_to_s3(upload, segfile)
 
     if opts.cleanup:
-        import shutil
+        from jcvi.apps.base import cleanup
 
-        shutil.rmtree(sampledir)
-        shutil.rmtree(cndir)
+        cleanup(cndir, sampledir)
 
 
 @dataclass

--- a/tests/apps/test_base.py
+++ b/tests/apps/test_base.py
@@ -83,7 +83,7 @@ def test_flatten(input_list, output_list):
 
 
 def test_cleanup():
-    from jcvi.apps.base import cleanup
+    from jcvi.apps.base import cleanup, mkdir
     from jcvi.formats.base import write_file
 
     write_file("a", "content_a", skipcheck=True)
@@ -93,6 +93,13 @@ def test_cleanup():
     assert not op.exists("a")
     assert not op.exists("b")
     assert not op.exists("c")
+
+    # Test cleanup with a directory
+    mkdir("adir")
+    write_file("bs", "content_bs", skipcheck=True)
+    cleanup("adir", "bs")
+    assert not op.exists("adir")
+    assert not op.exists("bs")
 
 
 def test_need_update():

--- a/tests/apps/test_base.py
+++ b/tests/apps/test_base.py
@@ -89,17 +89,23 @@ def test_cleanup():
     write_file("a", "content_a", skipcheck=True)
     write_file("b", "content_b", skipcheck=True)
     write_file("c", "content_c", skipcheck=True)
+    paths = ["a", "b", "c"]
+    for path in paths:
+        assert op.exists(path)
     cleanup("a", ["b", "c"])
-    assert not op.exists("a")
-    assert not op.exists("b")
-    assert not op.exists("c")
+    for path in paths:
+        assert not op.exists(path)
 
     # Test cleanup with a directory
     mkdir("adir")
+    mkdir("bdir")
     write_file("bs", "content_bs", skipcheck=True)
-    cleanup("adir", "bs")
-    assert not op.exists("adir")
-    assert not op.exists("bs")
+    paths = ["adir", "bdir", "bs"]
+    for path in paths:
+        assert op.exists(path)
+    cleanup("adir", ["bdir", "bs"])
+    for path in paths:
+        assert not op.exists(path)
 
 
 def test_need_update():


### PR DESCRIPTION
`FileShredder` is obsoleted by the use of `cleanup`. Just route all instances as well as `shutil.rmtree` to `cleanup`.