### PR TITLE
Add option --chrstyle to karyotype

### DIFF
--- a/jcvi/graphics/chromosome.py
+++ b/jcvi/graphics/chromosome.py
@@ -9,6 +9,7 @@ import logging
 import sys
 from itertools import groupby
 from math import ceil
+from typing import Tuple
 
 import numpy as np
 
@@ -27,10 +28,14 @@ from jcvi.graphics.base import (
     set1_n,
     set3_n,
 )
-from jcvi.graphics.glyph import BaseGlyph, RoundRect, plot_cap
+from jcvi.graphics.glyph import BaseGlyph, plot_cap
 
 
 class Chromosome(BaseGlyph):
+    # Chromosome styles: rect - rectangle, roundrect - rounded rectangle, auto -
+    # automatically pick the best style
+    Styles = ("auto", "rect", "roundrect")
+
     def __init__(
         self,
         ax,
@@ -95,42 +100,21 @@ class HorizontalChromosome(BaseGlyph):
         lw=1,
         fc=None,
         zorder=2,
-        roundrect=False,
+        style="auto",
     ):
         """
         Horizontal version of the Chromosome glyph above.
         """
+        assert style in Chromosome.Styles, f"Unknown style `{style}`"
+
         x1, x2 = sorted((x1, x2))
         super(HorizontalChromosome, self).__init__(ax)
-        pts, r = self.get_pts(x1, x2, y, height)
-        if roundrect:
-            RoundRect(
-                ax,
-                (x1, y - height * 0.5),
-                x2 - x1,
-                height,
-                fill=False,
-                lw=lw,
-                ec=ec,
-                zorder=zorder + 1,
-            )
-        else:
-            self.append(Polygon(pts, fill=False, lw=lw, ec=ec, zorder=zorder))
+        pts, r = self.get_pts(x1, x2, y, height, style=style)
+        self.append(Polygon(pts, fill=False, lw=lw, ec=ec, zorder=zorder + 1))
 
         if fc:
-            pts, r = self.get_pts(x1, x2, y, height / 2)
-            if roundrect:
-                RoundRect(
-                    ax,
-                    (x1, y - height / 4),
-                    x2 - x1,
-                    height / 2,
-                    fc=fc,
-                    lw=0,
-                    zorder=zorder,
-                )
-            else:
-                self.append(Polygon(pts, fc=fc, lw=0, zorder=zorder))
+            pts, r = self.get_pts(x1, x2, y, height / 2, style=style)
+            self.append(Polygon(pts, fc=fc, lw=0, zorder=zorder))
         if patch:
             rr = r * 0.9  # Shrink a bit for the patches
             # First patch is colored if there is an even number of patches, otherwise not colored
@@ -145,11 +129,13 @@ class HorizontalChromosome(BaseGlyph):
 
         self.add_patches()
 
-    def get_pts(self, x1, x2, y, height):
+    def get_pts(self, x1, x2, y, height, style="auto") -> Tuple[list, float]:
         h = height / 2
         r = height / (3**0.5)
 
-        if x2 - x1 < 2 * height:  # rectangle for small chromosomes
+        if style == "rect" or (
+            style == "auto" and x2 - x1 < 2 * height
+        ):  # rectangle for small chromosomes
             return [[x1, y + h], [x1, y - h], [x2, y - h], [x2, y + h]], r
 
         pts = []
@@ -205,7 +191,6 @@ class ChromosomeMap(object):
         subtitle,
         patchstart=None,
     ):
-
         width, height = xend - xstart, yend - ystart
 
         y = ystart - pad

--- a/jcvi/graphics/glyph.py
+++ b/jcvi/graphics/glyph.py
@@ -59,7 +59,7 @@ class Bezier(object):
         b = 3 * (p2 - p1) - c
         a = p3 - p0 - c - b
 
-        tsquared = t ** 2
+        tsquared = t**2
         tcubic = tsquared * t
         return a * tcubic + b * tsquared + c * t + p0
 
@@ -68,7 +68,6 @@ class RoundLabel(object):
     """Round rectangle around the text label"""
 
     def __init__(self, ax, x1, x2, t, lw=0, fill=False, fc="lavender", **kwargs):
-
         ax.text(
             x1,
             x2,
@@ -83,7 +82,6 @@ class RoundRect(object):
     """Round rectangle directly"""
 
     def __init__(self, ax, xy, width, height, shrink=0.1, label=None, **kwargs):
-
         shrink *= height
         x, y = xy
         pts = []
@@ -121,7 +119,6 @@ class DoubleSquare(object):
     """Square with a double-line margin"""
 
     def __init__(self, ax, x, y, radius=0.01, **kwargs):
-
         d = radius * 1.5
         ax.add_patch(Rectangle((x - d, y - d), 2 * d, 2 * d, fc="w", ec="k", zorder=10))
         d = radius
@@ -132,7 +129,6 @@ class DoubleCircle(object):
     """Circle with a double-line margin"""
 
     def __init__(self, ax, x, y, radius=0.01, **kwargs):
-
         ax.add_patch(CirclePolygon((x, y), radius * 1.4, resolution=50, fc="w", ec="k"))
         ax.add_patch(CirclePolygon((x, y), radius, resolution=50, **kwargs))
 
@@ -171,7 +167,6 @@ class TextCircle(object):
         fontweight="bold",
         **kwargs
     ):
-
         width, height = get_asymmetry(ax, radius)
         circle = Ellipse((x, y), width, height, fc=fc, ec=fc, zorder=zorder, **kwargs)
         ax.add_patch(circle)
@@ -260,7 +255,6 @@ class BaseGlyph(list):
 
 
 class Glyph(BaseGlyph):
-
     Styles = ("box", "arrow")
     Palette = ("orientation", "orthogroup")
     ArrowStyle = "Simple,head_length=1.5,head_width=7,tail_width=7"
@@ -335,7 +329,6 @@ class ExonGlyph(BaseGlyph):
     """Multiple rectangles linked together."""
 
     def __init__(self, ax, x, y, mrnabed, exonbeds, height=0.03, ratio=1, align="left"):
-
         super(ExonGlyph, self).__init__(ax)
         start, end = mrnabed.start, mrnabed.end
         xa = lambda a: x + (a - start) * ratio
@@ -364,7 +357,6 @@ class GeneGlyph(BaseGlyph):
         shadow=False,
         **kwargs
     ):
-
         super(GeneGlyph, self).__init__(ax)
         # Figure out the polygon vertices first
         orientation = 1 if x1 < x2 else -1
@@ -560,7 +552,6 @@ def plot_cap(center, t, r):
 
 
 def main():
-
     actions = (
         ("demo", "run a demo to showcase some common usages of various glyphs"),
         ("gff", "draw exons for genes based on gff files"),

--- a/jcvi/graphics/karyotype.py
+++ b/jcvi/graphics/karyotype.py
@@ -28,7 +28,7 @@ from typing import Optional
 from jcvi.apps.base import OptionParser
 from jcvi.compara.synteny import SimpleFile
 from jcvi.formats.bed import Bed
-from jcvi.graphics.chromosome import HorizontalChromosome
+from jcvi.graphics.chromosome import Chromosome, HorizontalChromosome
 from jcvi.graphics.glyph import TextCircle
 from jcvi.graphics.synteny import Shade
 from jcvi.graphics.base import AbstractLayout, markup, mpl, plt, savefig, update_figname
@@ -132,9 +132,8 @@ class Track(object):
         height=0.01,
         lw=1,
         draw=True,
-        roundrect=False,
+        chrstyle="auto",
     ):
-
         self.empty = t.empty
         if t.empty:
             return
@@ -182,14 +181,14 @@ class Track(object):
         self.lw = lw
 
         if draw:
-            self.draw(roundrect=roundrect)
+            self.draw(chrstyle=chrstyle)
 
     def __str__(self):
         return self.label
 
     def draw(
         self,
-        roundrect=False,
+        chrstyle="auto",
         keep_chrlabels=False,
         plot_label=True,
         plot_circles=True,
@@ -220,7 +219,7 @@ class Track(object):
                 height=self.height,
                 lw=self.lw,
                 fc=color,
-                roundrect=roundrect,
+                style=chrstyle,
             )
             hc.set_transform(tr)
             si = sid if keep_chrlabels else make_circle_name(sid, self.rev)
@@ -348,11 +347,11 @@ class Karyotype(object):
         generank=True,
         sizes=None,
         heightpad=0,
-        roundrect=False,
         keep_chrlabels=False,
         plot_label=True,
         plot_circles=True,
         shadestyle="curve",
+        chrstyle="auto",
         seed: Optional[int] = None,
     ):
         layout = Layout(layoutfile, generank=generank, seed=seed)
@@ -399,7 +398,7 @@ class Karyotype(object):
 
         for tr in tracks:
             tr.draw(
-                roundrect=roundrect,
+                chrstyle=chrstyle,
                 keep_chrlabels=keep_chrlabels,
                 plot_label=plot_label,
                 plot_circles=plot_circles,
@@ -435,6 +434,12 @@ def main():
         choices=Shade.Styles,
         help="Style of syntenic wedges",
     )
+    p.add_option(
+        "--chrstyle",
+        default="auto",
+        choices=Chromosome.Styles,
+        help="Style of chromosome labels",
+    )
     p.set_outfile("karyotype.pdf")
     opts, args, iopts = p.set_image_options(figsize="8x7")
 
@@ -454,6 +459,7 @@ def main():
         keep_chrlabels=opts.keep_chrlabels,
         plot_circles=(not opts.nocircles),
         shadestyle=opts.shadestyle,
+        chrstyle=opts.chrstyle,
         generank=(not opts.basepair),
         seed=iopts.seed,
     )

--- a/jcvi/projects/napus.py
+++ b/jcvi/projects/napus.py
@@ -74,7 +74,6 @@ class F4ALayout(LineFile):
 
 
 def main():
-
     actions = (
         ("ploidy", "plot napus macro-synteny (requires data)"),
         ("expr", "plot expression values between homeologs (requires data)"),
@@ -324,7 +323,6 @@ def fig3(args):
         generank=False,
         sizes=sizes,
         heightpad=r,
-        roundrect=True,
         plot_label=False,
     )
 


### PR DESCRIPTION
Add option `--chrstyle` to `karyotype` command. Example:

### Default style (automatically decide between rect and roundrect)

Note chr10 is changed to rectangle since it is too small to draw rounded caps.

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/106987/216888692-e55fb318-32f5-445b-b81b-e532de6052f8.png">

### `--chrstyle=rect`

<img width="1067" alt="image" src="https://user-images.githubusercontent.com/106987/216888791-7600913f-12a8-4ae0-91e6-94f1447961fb.png">

### `--chrstyle=roundrect`

<img width="1069" alt="image" src="https://user-images.githubusercontent.com/106987/216888908-9b3aabaf-0488-493d-b06a-e70e6b042efd.png">
 