### PR TITLE
Improve error logging for external tools

### DIFF
--- a/jcvi/apps/base.py
+++ b/jcvi/apps/base.py
@@ -22,7 +22,7 @@ from configparser import (
     ParsingError,
 )
 from socket import gethostname
-from subprocess import PIPE, call, check_call
+from subprocess import PIPE, call, check_output
 from optparse import OptionParser as OptionP, OptionGroup, SUPPRESS_HELP
 from typing import Any, Collection, List, Optional, Union
 
@@ -1140,6 +1140,7 @@ def sh(
     silent=False,
     shell="/bin/bash",
     check=False,
+    redirect_error=None,
 ):
     """
     simple wrapper for system calls
@@ -1184,8 +1185,8 @@ def sh(
         if log:
             logging.debug(cmd)
 
-        call_func = check_call if check else call
-        return call_func(cmd, shell=True, executable=shell)
+        call_func = check_output if check else call
+        return call_func(cmd, shell=True, executable=shell, stderr=redirect_error)
 
 
 def Popen(cmd, stdin=None, stdout=PIPE, debug=False, shell="/bin/bash"):

--- a/jcvi/graphics/base.py
+++ b/jcvi/graphics/base.py
@@ -319,6 +319,7 @@ def savefig(figname, dpi=150, iopts=None, cleanup=True):
         message = "savefig failed with message:"
         message += "\n{0}".format(str(e))
         logging.error(message)
+        logging.info("Try running again with --notex option to disable latex.")
         logging.debug(f"Matplotlib backend is: {mpl.get_backend()}")
         logging.debug(f"Attempted save as: {format}")
 

--- a/jcvi/graphics/base.py
+++ b/jcvi/graphics/base.py
@@ -316,11 +316,11 @@ def savefig(figname, dpi=150, iopts=None, cleanup=True):
     try:
         plt.savefig(figname, dpi=dpi, format=format)
     except Exception as e:
-        message = "savefig failed. Reset usetex to False."
+        message = "savefig failed with message:"
         message += "\n{0}".format(str(e))
-        logging.info(message)
-        rc("text", usetex=False)
-        plt.savefig(figname, dpi=dpi)
+        logging.error(message)
+        logging.debug(f"Matplotlib backend is: {mpl.get_backend()}")
+        logging.debug(f"Attempted save as: {format}")
 
     msg = "Figure saved to `{0}`".format(figname)
     if iopts:


### PR DESCRIPTION
Modified `jcvi.apps.base sh()` function to make cmd line calls with `subprocess.check_output()` instead of `subprocess.check_call()`.

check_output() waits until all output is read before it returns, so we can collect msg sent to stderr. It should otherwise behave the same as check_call().

Also added arg `redirect_error` to `sh()`, setting this to `subprocess.STDOUT` collects the error in the `.output` attribute of any error returned by `check_output`.

Modified calls to `lastal` in `jcvi.apps.align last()` to use this new error logging behaviour.

Modified `jcvi.graphics.base savefig()` to not attempt to re-save after  doing a `rc("text", usetex=False)`, this never worked anyway. Instead log suggestion to use `--notex` option.