### PR TITLE
Latex availability logging and error handling update

### DIFF
--- a/jcvi/apps/base.py
+++ b/jcvi/apps/base.py
@@ -22,7 +22,7 @@ from configparser import (
     ParsingError,
 )
 from socket import gethostname
-from subprocess import PIPE, call, check_call
+from subprocess import PIPE, call, check_output
 from optparse import OptionParser as OptionP, OptionGroup, SUPPRESS_HELP
 from typing import Any, Collection, List, Optional, Union
 
@@ -1140,6 +1140,7 @@ def sh(
     silent=False,
     shell="/bin/bash",
     check=False,
+    redirect_error=None,
 ):
     """
     simple wrapper for system calls
@@ -1184,8 +1185,8 @@ def sh(
         if log:
             logging.debug(cmd)
 
-        call_func = check_call if check else call
-        return call_func(cmd, shell=True, executable=shell)
+        call_func = check_output if check else call
+        return call_func(cmd, shell=True, executable=shell, stderr=redirect_error)
 
 
 def Popen(cmd, stdin=None, stdout=PIPE, debug=False, shell="/bin/bash"):

--- a/jcvi/apps/base.py
+++ b/jcvi/apps/base.py
@@ -588,6 +588,15 @@ class OptionParser(OptionP):
         assert "x" in opts.figsize
 
         iopts = ImageOptions(opts)
+
+        if opts.notex:
+            logging.info("--notex={}. latex use is disabled.".format(opts.notex))
+        elif not is_tex_available():
+            if not bool(which("latex")):
+                logging.info("`latex` not found. latex use is disabled.")
+            if not bool(which("lp")):
+                logging.info("`lp` not found. latex use is disabled.")
+
         setup_theme(style=opts.style, font=opts.font, usetex=iopts.usetex)
 
         return opts, args, iopts

--- a/jcvi/graphics/base.py
+++ b/jcvi/graphics/base.py
@@ -3,6 +3,7 @@
 
 import copy
 import os.path as op
+from os import remove
 import sys
 import logging
 
@@ -314,14 +315,19 @@ def savefig(figname, dpi=150, iopts=None, cleanup=True):
     except:
         format = "pdf"
     try:
+        logging.debug(f"Matplotlib backend is: {mpl.get_backend()}")
+        logging.debug(f"Attempting save as: {figname}")
         plt.savefig(figname, dpi=dpi, format=format)
     except Exception as e:
         message = "savefig failed with message:"
         message += "\n{0}".format(str(e))
         logging.error(message)
         logging.info("Try running again with --notex option to disable latex.")
-        logging.debug(f"Matplotlib backend is: {mpl.get_backend()}")
-        logging.debug(f"Attempted save as: {format}")
+        if op.exists(figname):
+            if op.getsize(figname) < 1000:
+                logging.debug(f"Cleaning up empty file: {figname}")
+                remove(figname)
+        sys.exit(1)
 
     msg = "Figure saved to `{0}`".format(figname)
     if iopts:

--- a/jcvi/graphics/base.py
+++ b/jcvi/graphics/base.py
@@ -319,6 +319,7 @@ def savefig(figname, dpi=150, iopts=None, cleanup=True):
         message = "savefig failed with message:"
         message += "\n{0}".format(str(e))
         logging.error(message)
+        logging.info("Try running again with --notex option to disable latex.")
         logging.debug(f"Matplotlib backend is: {mpl.get_backend()}")
         logging.debug(f"Attempted save as: {format}")
 

--- a/jcvi/graphics/base.py
+++ b/jcvi/graphics/base.py
@@ -316,11 +316,11 @@ def savefig(figname, dpi=150, iopts=None, cleanup=True):
     try:
         plt.savefig(figname, dpi=dpi, format=format)
     except Exception as e:
-        message = "savefig failed. Reset usetex to False."
+        message = "savefig failed with message:"
         message += "\n{0}".format(str(e))
-        logging.info(message)
-        rc("text", usetex=False)
-        plt.savefig(figname, dpi=dpi)
+        logging.error(message)
+        logging.debug(f"Matplotlib backend is: {mpl.get_backend()}")
+        logging.debug(f"Attempted save as: {format}")
 
     msg = "Figure saved to `{0}`".format(figname)
     if iopts:


### PR DESCRIPTION
1) Log specific cases where latex use is disabled.
- latex or lp not on path
- '--notex' is on

2) If savefig() fails an empty pdf may be created and successful save msg is displayed.
- Check for empty file and remove
- Exit with error is savefig fails