### PR TITLE
add ignore zero anchor parameter for skip no matches in batch search

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
 
       - name: Install BEDTools (Linux)
         run: sudo apt-get install bedtools


### PR DESCRIPTION
When parameter `--ignore_zero_anchor` is specified, if there is no anchor between two species, a warning message instead of an error exit would be caused. 