### PR TITLE
Fix dists

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ full-fledged applications.
 
 JCVI requires Python3 between v3.8 and v3.12.
 
+Some graphics modules require the [ImageMagick](https://imagemagick.org/index.php) library. 
+
+On MacOS this can be installed using Conda (see next section). If you are using a linux system (i.e. Ubuntu) you can install ImageMagick using apt-get:
+
+```bash
+sudo apt-get update
+sudo apt-get install libmagickwand-dev
+```
+
 A few modules may ask for locations of external programs,
 if the executable cannot be found in your `PATH`. 
 

--- a/README.md
+++ b/README.md
@@ -124,11 +124,9 @@ The external programs that are often used are:
 - [BEDTOOLS](http://code.google.com/p/bedtools/)
 - [EMBOSS](http://emboss.sourceforge.net/)
 
-## Installation
+### Managing dependencies with Conda
 
-**Installing JCVI in a Conda environment:**
-
-You can create a Conda environment with Python 3.12 and basic dependencies for JCVI using the YAML files in this repo.
+You can use the the YAML files in this repo to create an environment with basic JCVI dependencies.
 
 If you are new to Conda, we recommend the [Miniforge](https://conda-forge.org/download/) distribution.
 
@@ -151,8 +149,9 @@ conda activate jcvi-osx64
 
 After activating the Conda environment install JCVI using one of the following options.
 
+## Installation
 
-**Installation options:**  
+### Installation options
 
 1) Use pip to install the latest development version directly from this repo.
 
@@ -173,13 +172,15 @@ git clone git://github.com/tanghaibao/jcvi.git && cd jcvi
 pip install -e '.[tests]'
 ```
 
-**Test Installation:**  
+### Test Installation
 
 If installed successfully, you can check the version with:
 
 ```bash
 jcvi --version
 ```
+
+## Usage 
 
 Use `python -m` to call any of the modules installed with JCVI.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,6 @@ requires = [
 ]
 build-backend = "hatchling.build"
 
-[tool.hatch.build.hooks.custom]
-path = "build.py"
 
 # Project metadata and configuration
 [project]
@@ -88,12 +86,20 @@ allow-direct-references = true
 
 [tool.hatch.build]
 packages = ["src/jcvi"]
+artifacts = [
+    "src/jcvi/**/*.so",  # Linux/Mac shared objects
+    "src/jcvi/**/*.pyd", # Windows shared objects
+    "src/jcvi/**/*.c"    # Generated C files
+]
 
-[tool.hatch.version]
-source = "vcs"
+[tool.hatch.build.hooks.custom]
+path = "build.py"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/jcvi/_version.py"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.version.vcs]
 tag-pattern = "v*"
@@ -105,6 +111,8 @@ include = [
     "src/**/*.pyx",
     "README.md",
 ]
+
+force-include = { "build.py" = "build.py", "setup.py" = "setup.py"}
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/jcvi"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ jcvi = "jcvi.cli:main"
 allow-direct-references = true
 
 [tool.hatch.build]
-packages = ["src/jcvi"]
+packages = ["src"]
 artifacts = [
     "src/jcvi/**/*.so",  # Linux/Mac shared objects
     "src/jcvi/**/*.pyd", # Windows shared objects

--- a/src/jcvi/cli.py
+++ b/src/jcvi/cli.py
@@ -2,11 +2,14 @@
 import argparse
 from . import __version__
 
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--version', action='version', 
-                       version=f'%(prog)s {__version__}')
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
     args = parser.parse_args()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Work in Progress. Do not merge yet.

Wheel and Tarball produced by `hatch build` were not pip installable. 

wheel 
- [x] Need to include cython modules

tarball 
- [x] Include setup.py and build.py
- [x] Include jcvi package dir inside 'src' so that setup.py can find the cython modules to build.