### PR TITLE
Fix dists linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ sudo apt-get update
 sudo apt-get install libmagickwand-dev
 ```
 
+See the [Wand](https://docs.wand-py.org/en/0.2.4/guide/install.html) docs for instructions on installing ImageMagick on other systems.
+
 A few modules may ask for locations of external programs,
 if the executable cannot be found in your `PATH`.
 
@@ -130,7 +132,6 @@ The external programs that are often used are:
 You can use the the YAML files in this repo to create an environment with basic JCVI dependencies.
 
 If you are new to Conda, we recommend the [Miniforge](https://conda-forge.org/download/) distribution.
-
 
 ```bash
 conda env create -f environment.yml

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ computation related to assembly, annotation, and comparative genomics.
 | ------- | ---------------------------------------------------------------- |
 | Authors | Haibao Tang ([tanghaibao](http://github.com/tanghaibao))         |
 |         | Vivek Krishnakumar ([vivekkrish](https://github.com/vivekkrish)) |
+|         | Adam Taranto ([Adamtaranto](https://github.com/Adamtaranto))     |
 |         | Xingtan Zhang ([tangerzhang](https://github.com/tangerzhang))    |
 |         | Won Cheol Yim ([wyim-pgl](https://github.com/wyim-pgl))          |
 | Email   | <tanghaibao@gmail.com>                                           |
@@ -106,7 +107,7 @@ full-fledged applications.
 
 JCVI requires Python3 between v3.8 and v3.12.
 
-Some graphics modules require the [ImageMagick](https://imagemagick.org/index.php) library. 
+Some graphics modules require the [ImageMagick](https://imagemagick.org/index.php) library.
 
 On MacOS this can be installed using Conda (see next section). If you are using a linux system (i.e. Ubuntu) you can install ImageMagick using apt-get:
 
@@ -116,7 +117,7 @@ sudo apt-get install libmagickwand-dev
 ```
 
 A few modules may ask for locations of external programs,
-if the executable cannot be found in your `PATH`. 
+if the executable cannot be found in your `PATH`.
 
 The external programs that are often used are:
 
@@ -137,7 +138,7 @@ conda env create -f environment.yml
 conda activate jcvi
 ```
 
-Note: If you are using a Mac with an ARM64 (Apple Silicon) processor, some dependencies are not currently available from Bioconda for this architecture. 
+Note: If you are using a Mac with an ARM64 (Apple Silicon) processor, some dependencies are not currently available from Bioconda for this architecture.
 
 You can instead create a virtual OSX64 (intel) env like this:
 
@@ -180,7 +181,7 @@ If installed successfully, you can check the version with:
 jcvi --version
 ```
 
-## Usage 
+## Usage
 
 Use `python -m` to call any of the modules installed with JCVI.
 

--- a/build.py
+++ b/build.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
-from wheel._bdist_wheel import get_abi_tag, get_platform, tags
+from setuptools.command.bdist_wheel import get_abi_tag, get_platform, tags
 
 
 class CustomBuildHook(BuildHookInterface):

--- a/build.py
+++ b/build.py
@@ -1,7 +1,7 @@
 import subprocess
-import sysconfig
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from wheel._bdist_wheel import get_abi_tag, get_platform, tags
 
 
 class CustomBuildHook(BuildHookInterface):
@@ -15,8 +15,8 @@ class CustomBuildHook(BuildHookInterface):
 
     def _get_wheel_tag(self):
         # Without the tag, the wheel will be named jcvi-0.0.0-py3-none-any.whl
-        platform_tag = sysconfig.get_platform().replace("-", "_").replace(".", "_")
-        python_version = sysconfig.get_python_version().replace(".", "")  # e.g., "310"
-        python_impl = "cp"  # Assuming CPython. Modify if using PyPy or others.
-        abi_tag = f"{python_impl}{python_version}"
-        return f"{python_impl}{python_version}-{abi_tag}-{platform_tag}"
+        impl_name = tags.interpreter_name()
+        impl_ver = tags.interpreter_version()
+        abi_tag = get_abi_tag()
+        plat_tag = get_platform(None)
+        return f"{impl_name}{impl_ver}-{abi_tag}-{plat_tag}"

--- a/build.py
+++ b/build.py
@@ -1,9 +1,22 @@
 import subprocess
+import sysconfig
+
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
 class CustomBuildHook(BuildHookInterface):
     def initialize(self, version, build_data):
+        # Set the custom wheel tag
+        build_data["tag"] = self._get_wheel_tag()
+        print(f"Using custom wheel tag: {build_data['tag']}")
         # Run setup.py build_ext before main build
         subprocess.check_call(["python", "setup.py", "build_ext", "--inplace"])
         return super().initialize(version, build_data)
+
+    def _get_wheel_tag(self):
+        # Without the tag, the wheel will be named jcvi-0.0.0-py3-none-any.whl
+        platform_tag = sysconfig.get_platform().replace("-", "_").replace(".", "_")
+        python_version = sysconfig.get_python_version().replace(".", "")  # e.g., "310"
+        python_impl = "cp"  # Assuming CPython. Modify if using PyPy or others.
+        abi_tag = f"{python_impl}{python_version}"
+        return f"{python_impl}{python_version}-{abi_tag}-{platform_tag}"

--- a/build.py
+++ b/build.py
@@ -19,4 +19,7 @@ class CustomBuildHook(BuildHookInterface):
         impl_ver = tags.interpreter_version()
         abi_tag = get_abi_tag()
         plat_tag = get_platform(None)
+        plat_tag = (  # macosx_11.0 => macosx_11_0
+            plat_tag.lower().replace("-", "_").replace(".", "_").replace(" ", "_")
+        )
         return f"{impl_name}{impl_ver}-{abi_tag}-{plat_tag}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@
 requires = [
     "hatchling",  # Build backend
     "hatch-vcs",  # Version control system plugin for dynamic versioning
-    "setuptools",  # Setuptools for compiling C extensions
-    "cython",  # Cython for compiling C extensions
+    "setuptools", # Setuptools for compiling C extensions
+    "cython",     # Cython for compiling C extensions
     "numpy",      # NumPy for numerical operations and C extension includes
 ]
 build-backend = "hatchling.build"
@@ -16,11 +16,11 @@ name = "jcvi"
 description = "Python utility libraries on genome assembly, annotation and comparative genomics"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "BSD"}
+license = { text = "BSD" }
 authors = [
-    {name = "Haibao Tang", email = "tanghaibao@gmail.com"},
-    {name = "Vivek Krishnakumar"},
-    {name = "Jingping Li"}
+    { name = "Haibao Tang", email = "tanghaibao@gmail.com" },
+    { name = "Vivek Krishnakumar" },
+    { name = "Adam Taranto" },
 ]
 
 classifiers = [
@@ -28,7 +28,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Topic :: Scientific/Engineering :: Bio-Informatics"
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 
 dependencies = [
@@ -60,19 +60,13 @@ dependencies = [
     "scipy",
     "seaborn",
     "Wand",
-    "webcolors"
+    "webcolors",
 ]
 
 dynamic = ["version"]
 
 [project.optional-dependencies]
-tests = [
-    "mock",
-    "pytest-benchmark",
-    "pytest-cov",
-    "pytest",
-    "PyYAML",
-]
+tests = ["mock", "pytest-benchmark", "pytest-cov", "pytest", "PyYAML"]
 
 [project.urls]
 homepage = "http://github.com/tanghaibao/jcvi"
@@ -86,11 +80,6 @@ allow-direct-references = true
 
 [tool.hatch.build]
 packages = ["src"]
-artifacts = [
-    "src/jcvi/**/*.so",  # Linux/Mac shared objects
-    "src/jcvi/**/*.pyd", # Windows shared objects
-    "src/jcvi/**/*.c"    # Generated C files
-]
 
 [tool.hatch.build.hooks.custom]
 path = "build.py"
@@ -106,13 +95,14 @@ tag-pattern = "v*"
 fallback-version = "0.0.0"
 
 [tool.hatch.build.targets.sdist]
-include = [
-    "src/**/*.py",
-    "src/**/*.pyx",
-    "README.md",
-]
-
-force-include = { "build.py" = "build.py", "setup.py" = "setup.py"}
+include = ["src/**/*.py", "src/**/*.pyx", "README.md"]
+force-include = { "build.py" = "build.py", "setup.py" = "setup.py" }
+exclude = ["src/jcvi/**/*.so", "src/jcvi/**/*.pyd", "src/jcvi/**/*.c"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/jcvi"]
+artifacts = [
+    "src/jcvi/**/*.so",  # Linux/Mac shared objects
+    "src/jcvi/**/*.pyd", # Windows shared objects
+    "src/jcvi/**/*.c",   # Generated C files
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "hatchling",  # Build backend
     "hatch-vcs",  # Version control system plugin for dynamic versioning
     "setuptools", # Setuptools for compiling C extensions
+    "wheel",      # Wheel for packaging
     "cython",     # Cython for compiling C extensions
     "numpy",      # NumPy for numerical operations and C extension includes
 ]

--- a/src/jcvi/__init__.py
+++ b/src/jcvi/__init__.py
@@ -3,6 +3,7 @@ from datetime import datetime
 __author__ = (
     "Haibao Tang",
     "Vivek Krishnakumar",
+    "Adam Taranto",
     "Xingtan Zhang",
     "Won Cheol Yim",
 )


### PR DESCRIPTION
## Changes

- Remove `.so` from source tarball
- Name `.whl` with platform specific tag

## Testing

- On linux, manually tested with `pip install` on both source tarball and wheel

One caveat, I may have to install `hatchling`, `hatch-vcs`, or `hatch` despite them being in `[build-system]`.

I am not sure if the standalone tarball and wheel, once hosted on PyPI, will be able to trigger installing the dependencies first  on the client machine.
