### PR TITLE
Add condition to skip PRs authored by bots

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,8 +18,8 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    # Skip any PRs authored by a bot
-    if: github.event.pull_request.user.type != 'Bot'
+    # Skip PRs authored by dependabot
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
 
     # Skip any PRs authored by a bot
     if: github.event.pull_request.user.type != 'Bot'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,9 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
+    # Skip any PRs authored by a bot
+    if: github.event.pull_request.user.type != 'Bot'
+    
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Claude code review will be skipped on any PR opened by a bot.

Currently CCR is called but refuses to process any PRs opened by bots i.e Dependabot, creates error.

I don't think this should affect PRs opened by copilot or other agents. If it does then condition can be set to ignore dependabot PRs specifically.