### PR TITLE
test: isolate every test in a temp cwd and guard against repo pollution

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,14 +51,16 @@ jobs:
           # pollution this step exists to catch and still report clean.
           # Scoped to tests/ because src/ legitimately holds ignored build
           # artifacts (_version.py, generated .c/.so).
+          # Written outside the checkout, so the report is not itself a stray.
+          dirty="${RUNNER_TEMP:-/tmp}/dirty.txt"
           git status --porcelain --ignored=traditional -- tests/ \
-            | grep -vE '__pycache__|\.pyc$|\.coverage$|coverage\.xml$' >dirty.txt || true
+            | grep -vE '__pycache__|\.pyc$|\.coverage$|coverage\.xml$' >"$dirty" || true
           # Elsewhere, tracked-file edits and non-ignored strays still count.
           # uv.lock is excluded: `uv sync` may write it during this job.
-          git status --porcelain --untracked-files=all -- . ':!tests' ':!uv.lock' >>dirty.txt
-          if [ -s dirty.txt ]; then
+          git status --porcelain --untracked-files=all -- . ':!tests' ':!uv.lock' >>"$dirty"
+          if [ -s "$dirty" ]; then
             echo "::error::Tests created or modified files inside the repo:"
-            cat dirty.txt
+            cat "$dirty"
             exit 1
           fi
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -46,7 +46,16 @@ jobs:
       # Tests must not write into the checkout; see tests/conftest.py
       - name: Check tests left the working tree clean
         run: |
-          git status --porcelain --untracked-files=all -- tests/ src/ >dirty.txt
+          # `--ignored` matters: .gitignore lists test outputs such as
+          # tests/**/*.pdf, so without it a test can recreate exactly the
+          # pollution this step exists to catch and still report clean.
+          # Scoped to tests/ because src/ legitimately holds ignored build
+          # artifacts (_version.py, generated .c/.so).
+          git status --porcelain --ignored=traditional -- tests/ \
+            | grep -vE '__pycache__|\.pyc$|\.coverage$|coverage\.xml$' >dirty.txt || true
+          # Elsewhere, tracked-file edits and non-ignored strays still count.
+          # uv.lock is excluded: `uv sync` may write it during this job.
+          git status --porcelain --untracked-files=all -- . ':!tests' ':!uv.lock' >>dirty.txt
           if [ -s dirty.txt ]; then
             echo "::error::Tests created or modified files inside the repo:"
             cat dirty.txt

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,6 +43,15 @@ jobs:
       - name: Test with pytest
         run: |
           uv run pytest
+      # Tests must not write into the checkout; see tests/conftest.py
+      - name: Check tests left the working tree clean
+        run: |
+          git status --porcelain --untracked-files=all -- tests/ src/ >dirty.txt
+          if [ -s dirty.txt ]; then
+            echo "::error::Tests created or modified files inside the repo:"
+            cat dirty.txt
+            exit 1
+          fi
 
 # Upload coverage report to Codecov
 # Only upload coverage for the latest Python version on Ubuntu

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,20 +43,15 @@ jobs:
       - name: Test with pytest
         run: |
           uv run pytest
-      # Tests must not write into the checkout; see tests/conftest.py
       - name: Check tests left the working tree clean
         run: |
-          # `--ignored` matters: .gitignore lists test outputs such as
-          # tests/**/*.pdf, so without it a test can recreate exactly the
-          # pollution this step exists to catch and still report clean.
-          # Scoped to tests/ because src/ legitimately holds ignored build
-          # artifacts (_version.py, generated .c/.so).
-          # Written outside the checkout, so the report is not itself a stray.
+          # Report lives outside the checkout so it is not itself a stray.
           dirty="${RUNNER_TEMP:-/tmp}/dirty.txt"
+          # --ignored: .gitignore hides test outputs like tests/**/*.pdf.
+          # Only for tests/; src/ has legitimate ignored build artifacts.
           git status --porcelain --ignored=traditional -- tests/ \
             | grep -vE '__pycache__|\.pyc$|\.coverage$|coverage\.xml$' >"$dirty" || true
-          # Elsewhere, tracked-file edits and non-ignored strays still count.
-          # uv.lock is excluded: `uv sync` may write it during this job.
+          # uv.lock excluded: `uv sync` may write it during this job.
           git status --porcelain --untracked-files=all -- . ':!tests' ':!uv.lock' >>"$dirty"
           if [ -s "$dirty" ]; then
             echo "::error::Tests created or modified files inside the repo:"

--- a/tests/apps/test_base.py
+++ b/tests/apps/test_base.py
@@ -35,11 +35,10 @@ def test_sample_N():
     assert a == [2, 3, 1, 2]
 
 
-def test_download(tmp_path, monkeypatch):
+def test_download():
     from jcvi.apps.base import cleanup, download
     from jcvi.apps.vecscreen import ECOLI_URL, UNIVEC_URL
 
-    monkeypatch.chdir(tmp_path)
     ret = download("http://www.google.com")
     assert ret == "index.html"
     cleanup(ret)
@@ -84,11 +83,10 @@ def test_flatten(input_list, output_list):
     assert flatten(input_list) == output_list
 
 
-def test_cleanup(tmp_path, monkeypatch):
+def test_cleanup():
     from jcvi.apps.base import cleanup, mkdir
     from jcvi.formats.base import write_file
 
-    monkeypatch.chdir(tmp_path)
     write_file("a", "content_a", skipcheck=True)
     write_file("b", "content_b", skipcheck=True)
     write_file("c", "content_c", skipcheck=True)
@@ -111,11 +109,10 @@ def test_cleanup(tmp_path, monkeypatch):
         assert not op.exists(path)
 
 
-def test_need_update(tmp_path, monkeypatch):
+def test_need_update():
     from jcvi.apps.base import cleanup, need_update
     from jcvi.formats.base import write_file
 
-    monkeypatch.chdir(tmp_path)
     assert need_update("does_not_exist.txt", "does_not_exist.txt")
 
     write_file("a", "content_a", skipcheck=True)
@@ -156,10 +153,9 @@ def test_set_image_options():
     g.add_argument("--group", default="jcvi", help="pytest coverage")
 
 
-def test_getpath(tmp_path, monkeypatch):
+def test_getpath():
     from jcvi.apps.base import getpath
 
-    monkeypatch.chdir(tmp_path)
     with mock.patch("builtins.input", lambda _: "e\rvvvvvvvv = zzzzzzzz\n"):
         assert getpath("not-part-of-path", name="CLUSTALW2", warn="warn") is None
 

--- a/tests/apps/test_fetch.py
+++ b/tests/apps/test_fetch.py
@@ -8,11 +8,10 @@ from unittest.mock import patch
 
 @patch("builtins.input", return_value="username")
 @patch("getpass.getpass", return_value="password")
-def test_get_cookies(mock_username, mock_password, tmp_path, monkeypatch):
+def test_get_cookies(mock_username, mock_password):
     from jcvi.apps.fetch import get_cookies, PHYTOZOME_COOKIES
     from jcvi.apps.base import which
 
-    monkeypatch.chdir(tmp_path)
     if which("curl"):
         assert get_cookies() == PHYTOZOME_COOKIES
     else:

--- a/tests/assembly/test_allmaps.py
+++ b/tests/assembly/test_allmaps.py
@@ -18,11 +18,10 @@ def test_weights():
     assert weights.maps == ["JMMale", "JMFemale"]
 
 
-def test_liftover(tmp_path, monkeypatch):
+def test_liftover():
     from jcvi.assembly.allmaps import liftover
     from ..config import compare_line_by_line
 
-    monkeypatch.chdir(tmp_path)
     chainfile = datafile("inputs/JM-2.chain")
     bedfile = datafile("inputs/JM-2.bed")
     liftedbedfile = "JM-2.lifted.bed"
@@ -31,10 +30,9 @@ def test_liftover(tmp_path, monkeypatch):
     compare_line_by_line(liftedbedfile, expected)
 
 
-def test_path(tmp_path, monkeypatch):
+def test_path(tmp_path):
     import shutil
 
-    monkeypatch.chdir(tmp_path)
     bedfile = str(tmp_path / "JM-2.bed")
     shutil.copy(datafile("inputs/JM-2.bed"), bedfile)
     fastafile = datafile("inputs/scaffolds.fasta.gz")

--- a/tests/config.py
+++ b/tests/config.py
@@ -23,7 +23,7 @@ import time
 import yaml
 
 from importlib import import_module
-from shutil import rmtree as rmdir_
+from shutil import copytree, rmtree as rmdir_
 from typing import Optional, Tuple
 
 # https://stackoverflow.com/questions/16571150/how-to-capture-stdout-output-from-a-python-function-call
@@ -119,6 +119,11 @@ def test_script(
     start_time = time.time()
 
     tmp_dir = tempfile.mkdtemp()
+
+    # Some scripts write sidecar files next to their inputs -- gffutils, for
+    # example, creates a `.db` alongside the GFF it reads. Point `__DIR__` at a
+    # throwaway copy so those writes cannot land in the checkout.
+    work_dir = copytree(work_dir, op.join(tmp_dir, "work"))
 
     opts, args = "", ""
     if options:

--- a/tests/config.py
+++ b/tests/config.py
@@ -91,7 +91,9 @@ def generate_tests(metafunc, domain):
                     test_params["args"],
                     test_params["outputs"],
                     test_params["references"],
-                    script_dir,
+                    # Absolute, so that `__DIR__` and reference paths resolve
+                    # correctly no matter what the test's working directory is
+                    op.abspath(script_dir),
                 )
             )
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -91,9 +91,7 @@ def generate_tests(metafunc, domain):
                     test_params["args"],
                     test_params["outputs"],
                     test_params["references"],
-                    # Absolute, so that `__DIR__` and reference paths resolve
-                    # correctly no matter what the test's working directory is
-                    op.abspath(script_dir),
+                    op.abspath(script_dir),  # absolute: resolution is cwd-independent
                 )
             )
 
@@ -120,9 +118,8 @@ def test_script(
 
     tmp_dir = tempfile.mkdtemp()
 
-    # Some scripts write sidecar files next to their inputs -- gffutils, for
-    # example, creates a `.db` alongside the GFF it reads. Point `__DIR__` at a
-    # throwaway copy so those writes cannot land in the checkout.
+    # Scripts may write sidecars next to their inputs (gffutils' `.db`), so
+    # point `__DIR__` at a throwaway copy.
     work_dir = copytree(work_dir, op.join(tmp_dir, "work"))
 
     opts, args = "", ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+"""
+Shared pytest fixtures for the jcvi test suite.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_cwd(tmp_path, monkeypatch):
+    """
+    Run every test in its own temporary directory.
+
+    Many jcvi entry points write their outputs relative to the current working
+    directory. Without this, running the suite from the repo root leaves stray
+    files behind in the checkout and in `tests/*/data` directories. Making the
+    isolation automatic means new tests get it for free, rather than each one
+    having to remember to `monkeypatch.chdir(tmp_path)`.
+
+    Tests that need the real data directories should reference them via
+    `op.join(op.dirname(__file__), "data")`, which is unaffected by the chdir.
+    """
+    monkeypatch.chdir(tmp_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,36 @@
 Shared pytest fixtures for the jcvi test suite.
 """
 
+import os
+import os.path as op
+import shutil
+
 import pytest
+
+
+@pytest.fixture
+def copy_data(tmp_path):
+    """
+    Copy the contents of a test data directory into the isolated working dir.
+
+    Returns a callable taking the data directory to copy from.
+
+    Tests must *copy* rather than symlink: several entry points write outputs
+    whose names collide with their inputs (`grape_peach.bed`, `calibrate.json`),
+    and writing through a symlink modifies the link target, i.e. the checked-in
+    data directory. Copying keeps those writes inside the temporary directory.
+    """
+
+    def _copy(data_dir: str) -> str:
+        for fname in os.listdir(data_dir):
+            src, dst = op.join(data_dir, fname), op.join(str(tmp_path), fname)
+            if op.isdir(src):
+                shutil.copytree(src, dst)
+            else:
+                shutil.copy2(src, dst)
+        return str(tmp_path)
+
+    return _copy
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,14 +15,10 @@ import pytest
 @pytest.fixture
 def copy_data(tmp_path):
     """
-    Copy the contents of a test data directory into the isolated working dir.
+    Copy a test data directory into the isolated working dir.
 
-    Returns a callable taking the data directory to copy from.
-
-    Tests must *copy* rather than symlink: several entry points write outputs
-    whose names collide with their inputs (`grape_peach.bed`, `calibrate.json`),
-    and writing through a symlink modifies the link target, i.e. the checked-in
-    data directory. Copying keeps those writes inside the temporary directory.
+    Copy rather than symlink: outputs whose names collide with inputs
+    (`grape_peach.bed`, `calibrate.json`) would write through to the checkout.
     """
 
     def _copy(data_dir: str) -> str:
@@ -42,13 +38,7 @@ def isolate_cwd(tmp_path, monkeypatch):
     """
     Run every test in its own temporary directory.
 
-    Many jcvi entry points write their outputs relative to the current working
-    directory. Without this, running the suite from the repo root leaves stray
-    files behind in the checkout and in `tests/*/data` directories. Making the
-    isolation automatic means new tests get it for free, rather than each one
-    having to remember to `monkeypatch.chdir(tmp_path)`.
-
-    Tests that need the real data directories should reference them via
-    `op.join(op.dirname(__file__), "data")`, which is unaffected by the chdir.
+    Many entry points write relative to the cwd; autouse keeps new tests
+    isolated without each one opting in.
     """
     monkeypatch.chdir(tmp_path)

--- a/tests/formats/test_obo.py
+++ b/tests/formats/test_obo.py
@@ -1,7 +1,6 @@
-def test_oboreader(tmp_path, monkeypatch):
+def test_oboreader():
     from jcvi.formats.obo import GODag_from_GO
 
-    monkeypatch.chdir(tmp_path)
     go, obo_file = GODag_from_GO()
     r1, r2, r3 = [
         rec

--- a/tests/graphics/test_glyph.py
+++ b/tests/graphics/test_glyph.py
@@ -4,6 +4,5 @@
 from jcvi.graphics.glyph import demo
 
 
-def test_demo(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
+def test_demo():
     demo([])

--- a/tests/graphics/test_grabseeds.py
+++ b/tests/graphics/test_grabseeds.py
@@ -1,14 +1,10 @@
-import os
 import os.path as op
 
 from jcvi.graphics.grabseeds import calibrate, seeds
 
 
-def test_main(tmp_path, monkeypatch):
-    data_dir = op.join(op.dirname(__file__), "data")
-    for fname in os.listdir(data_dir):
-        os.symlink(op.join(data_dir, fname), op.join(str(tmp_path), fname))
-    monkeypatch.chdir(tmp_path)
+def test_main(copy_data):
+    copy_data(op.join(op.dirname(__file__), "data"))
 
     output_image = "test.pdf"
     seeds(["test.JPG"])

--- a/tests/graphics/test_karyotype.py
+++ b/tests/graphics/test_karyotype.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
-import os
 import os.path as op
 import pytest
 
@@ -26,11 +25,8 @@ def test_make_circle_name(sid, rev, expected):
     assert make_circle_name(sid, rev) == expected, "Expect {}".format(expected)
 
 
-def test_main(tmp_path, monkeypatch):
-    data_dir = op.join(op.dirname(__file__), "data")
-    for fname in os.listdir(data_dir):
-        os.symlink(op.join(data_dir, fname), op.join(str(tmp_path), fname))
-    monkeypatch.chdir(tmp_path)
+def test_main(copy_data):
+    copy_data(op.join(op.dirname(__file__), "data"))
 
     image_name = karyotype_main(["seqids", "layout"])
     assert op.exists(image_name)

--- a/tests/graphics/test_landscape.py
+++ b/tests/graphics/test_landscape.py
@@ -1,14 +1,10 @@
-import os
 import os.path as op
 
 from jcvi.graphics.landscape import depth, stack
 
 
-def test_depth(tmp_path, monkeypatch):
-    data_dir = op.join(op.dirname(__file__), "data")
-    for fname in os.listdir(data_dir):
-        os.symlink(op.join(data_dir, fname), op.join(str(tmp_path), fname))
-    monkeypatch.chdir(tmp_path)
+def test_depth(copy_data):
+    copy_data(op.join(op.dirname(__file__), "data"))
 
     image_name = depth(
         [
@@ -23,11 +19,8 @@ def test_depth(tmp_path, monkeypatch):
     assert op.exists(image_name)
 
 
-def test_stack(tmp_path, monkeypatch):
-    data_dir = op.join(op.dirname(__file__), "data")
-    for fname in os.listdir(data_dir):
-        os.symlink(op.join(data_dir, fname), op.join(str(tmp_path), fname))
-    monkeypatch.chdir(tmp_path)
+def test_stack(copy_data):
+    copy_data(op.join(op.dirname(__file__), "data"))
 
     image_name = stack(
         ["TAIR10_organelles.fas.gz", "--stacks=exons", "--window=25000", "--shift=5000"]

--- a/tests/graphics/test_synteny.py
+++ b/tests/graphics/test_synteny.py
@@ -50,11 +50,8 @@ def test_invalid_layoutline(row, delimiter, error):
         _ = LayoutLine(row, delimiter)
 
 
-def test_main(tmp_path, monkeypatch):
-    data_dir = op.join(op.dirname(__file__), "data")
-    for fname in os.listdir(data_dir):
-        os.symlink(op.join(data_dir, fname), op.join(str(tmp_path), fname))
-    monkeypatch.chdir(tmp_path)
+def test_main(copy_data):
+    copy_data(op.join(op.dirname(__file__), "data"))
 
     merge(["grape.bed", "peach.bed", "-o", "grape_peach.bed"])
     image_name = synteny_main(["blocks", "grape_peach.bed", "blocks.layout"])

--- a/tests/graphics/test_tree.py
+++ b/tests/graphics/test_tree.py
@@ -12,11 +12,10 @@ matplotlib.use("Agg")
 import pytest
 
 
-def test_tree_main(tmp_path, monkeypatch):
+def test_tree_main(tmp_path):
     """Render the built-in demo tree to a PNG and check the file is created."""
     from jcvi.graphics.tree import main as tree_main
 
-    monkeypatch.chdir(tmp_path)
     tree_main(["demo", "--format", "png"])
     assert op.exists(str(tmp_path / "demo.png"))
 


### PR DESCRIPTION
Follow-up to #853, which stopped test pollution by adding `monkeypatch.chdir(tmp_path)` to ~15 tests individually. This makes isolation systemic so it can't regress.

## Why

No project-level `conftest.py` existed, so pytest ran with the repo root as cwd and isolation was opt-in per test — the next test written pollutes again.

## Changes

- **`tests/conftest.py`** — autouse fixture chdir'ing every test into its own `tmp_path`; plus a shared `copy_data` fixture.
- **`.github/workflows/pytest.yml`** — fails CI if a run leaves the tree dirty.
- **`tests/config.py`** — `work_dir` was relative and `op.abspath`'d at resolve time, so every `__DIR__` substitution depended on the cwd (33 failures once the cwd moved). Now resolved at collection time, against a throwaway copy of the test dir so sidecar writes (gffutils `.db`) can't reach the checkout.
- Removed the now-redundant `monkeypatch.chdir` calls from #853.

## Fixes found while verifying

**Symlinks wrote through to the data dir.** The graphics tests symlinked all of `tests/graphics/data/` into `tmp_path`. Writes follow symlinks to their target, so outputs colliding with input names (`grape_peach.bed`, `calibrate.json`) landed back in the checked-in data dir. This was happening live — those files carried timestamps from my own test runs. Now copied, via `copy_data`, which also de-duplicates the loop repeated across five tests.

**The guard was blind to it.** `.gitignore` lists `tests/**/*.pdf`, `*.synfind`, `*.lifted.anchors`, `grape_peach.bed` — band-aids for this exact pollution — and `git status` hides ignored files unless asked. The guard now passes `--ignored` for `tests/`, filtering only genuine caches. Thanks to the Codex review for catching this independently.

## Verification

Cleared all 14 stray artifacts (8 of them invisible to plain `git status`), then ran the full suite: **257 passed**, and `git status --ignored` on `tests/` comes back empty. Reproduced across repeated runs.

Since pollution no longer occurs, the `.gitignore` band-aids at lines 75-78 are now dead and could be dropped in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Bgop1ZMQQiBoQv235xain