### PR TITLE
Fix typos in code comments

### DIFF
--- a/src/jcvi/apps/wga2ribbon.py
+++ b/src/jcvi/apps/wga2ribbon.py
@@ -162,7 +162,7 @@ def readLASTZ(infile, minID=50):
     counter = 0
     # Read in split rows
     for row in content:
-        # Ignore lines begining with '#'
+        # Ignore lines beginning with '#'
         if row[0][0] == "#":
             continue
         # Count if hit identity exceeds threshold
@@ -245,7 +245,7 @@ def readPAF(infile, minID=50):
     counter = 0
     # Read in split rows
     for row in content:
-        # Ignore lines begining with '#'
+        # Ignore lines beginning with '#'
         if row[0][0] == "#":
             continue
         # Count if hit identity exceeds threshold

--- a/src/jcvi/assembly/allmaps.py
+++ b/src/jcvi/assembly/allmaps.py
@@ -655,7 +655,7 @@ class Weights(DictFile):
             logger.debug("Weight for `%s` set to %d.", m, default)
 
     def get_pivot(self, mapnames):
-        # Break ties by occurence in file
+        # Break ties by occurrence in file
         common_mapnames = set(self.maps) & set(mapnames)
         if not common_mapnames:
             logger.error("No common names found between %s and %s", self.maps, mapnames)


### PR DESCRIPTION
Fixes spelling typos in code comments. No code change.

- `occurence` should be `occurrence` (src/jcvi/assembly/allmaps.py)
- `begining` should be `beginning` (src/jcvi/apps/wga2ribbon.py, two occurrences)
